### PR TITLE
Prune Travis CI build menu

### DIFF
--- a/.scripts/ci_build.sh
+++ b/.scripts/ci_build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # The return code will capture an error from ANY of the functions in the pipe
-set -o pipefail
+set -euo pipefail
 cmake --build . -- --jobs=2 VERBOSE=1 | tee build.log | grep "Building"
 RESULT=$?
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,134 +20,8 @@ branches:
 matrix:
   include:
     - os: linux
-      compiler: clang
+      compiler: gcc
       addons: &1
-        apt:
-          sources:
-            - llvm-toolchain-precise-3.5
-            - ubuntu-toolchain-r-test
-            - boost-latest
-            - george-edison55-precise-backports
-          packages:
-            - cmake
-            - cmake-data
-            - clang-3.5
-            - libboost1.55-all-dev
-            - gfortran
-      env:
-        - CXX_COMPILER='clang++-3.5'
-        - C_COMPILER='clang-3.5'
-        - Fortran_COMPILER='gfortran'
-        - BUILD_TYPE='release'
-        - PYTHON_VER='2.7'
-    - os: osx
-      osx_image: xcode7.3
-      compiler: clang
-      env:
-        - CXX_COMPILER='clang++'
-        - C_COMPILER='clang'
-        - Fortran_COMPILER='gfortran-4.8'
-        - BUILD_TYPE='release'
-        - PYTHON_VER='2.7'
-        - HOMEBREW_GCC='homebrew/versions/gcc48'
-    - os: linux
-      compiler: clang
-      addons: &2
-        apt:
-          sources:
-            - llvm-toolchain-precise-3.6
-            - ubuntu-toolchain-r-test
-            - boost-latest
-            - george-edison55-precise-backports
-          packages:
-            - cmake
-            - cmake-data
-            - clang-3.6
-            - libboost1.55-all-dev
-            - gfortran
-      env:
-        - CXX_COMPILER='clang++-3.6'
-        - C_COMPILER='clang-3.6'
-        - Fortran_COMPILER='gfortran'
-        - BUILD_TYPE='release'
-        - STATIC='--static'
-        - PYTHON_VER='3.5'
-    - os: osx
-      osx_image: xcode7.3
-      compiler: gcc
-      env:
-        - CXX_COMPILER='g++-4.8'
-        - C_COMPILER='gcc-4.8'
-        - Fortran_COMPILER='gfortran-4.8'
-        - BUILD_TYPE='release'
-        - PYTHON_VER='2.7'
-        - HOMEBREW_GCC='homebrew/versions/gcc48'
-    - os: linux
-      compiler: clang
-      addons: &3
-        apt:
-          sources:
-            - llvm-toolchain-precise-3.7
-            - ubuntu-toolchain-r-test
-            - boost-latest
-            - george-edison55-precise-backports
-          packages:
-            - cmake
-            - cmake-data
-            - clang-3.7
-            - libboost1.55-all-dev
-            - gfortran
-      env:
-        - CXX_COMPILER='clang++-3.7'
-        - C_COMPILER='clang-3.7'
-        - Fortran_COMPILER='gfortran'
-        - PYTHON_VER='2.7'
-        - BUILD_TYPE='release'
-    - os: osx
-      osx_image: xcode7.3
-      compiler: clang
-      env:
-        - CXX_COMPILER='clang++'
-        - C_COMPILER='clang'
-        - Fortran_COMPILER='gfortran-4.9'
-        - BUILD_TYPE='release'
-        - PYTHON_VER='3.5'
-        - HOMEBREW_GCC='homebrew/versions/gcc49'
-        - STATIC='--static'
-    - os: linux
-      compiler: clang
-      addons: &4
-        apt:
-          sources:
-            - llvm-toolchain-precise-3.8
-            - ubuntu-toolchain-r-test
-            - boost-latest
-            - george-edison55-precise-backports
-          packages:
-            - cmake
-            - cmake-data
-            - clang-3.8
-            - libboost1.55-all-dev
-            - gfortran
-      env:
-        - CXX_COMPILER='clang++-3.8'
-        - C_COMPILER='clang-3.8'
-        - Fortran_COMPILER='gfortran'
-        - BUILD_TYPE='release'
-        - PYTHON_VER='3.5'
-    - os: osx
-      osx_image: xcode7.3
-      compiler: gcc
-      env:
-        - CXX_COMPILER='g++-4.9'
-        - C_COMPILER='gcc-4.9'
-        - Fortran_COMPILER='gfortran-4.9'
-        - BUILD_TYPE='release'
-        - PYTHON_VER='3.5'
-        - HOMEBREW_GCC='homebrew/versions/gcc49'
-    - os: linux
-      compiler: gcc
-      addons: &5
         apt:
           sources:
             - ubuntu-toolchain-r-test
@@ -166,6 +40,29 @@ matrix:
         - Fortran_COMPILER='gfortran-4.6'
         - BUILD_TYPE='release'
         - PYTHON_VER='2.7'
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-precise-3.5
+            - ubuntu-toolchain-r-test
+            - boost-latest
+            - george-edison55-precise-backports
+          packages:
+            - cmake
+            - cmake-data
+            - clang-3.5
+            - libboost1.55-all-dev
+            - gfortran
+      env:
+        - CXX_COMPILER='clang++-3.5'
+        - C_COMPILER='clang-3.5'
+        - Fortran_COMPILER='gfortran'
+        - BUILD_TYPE='release'
+        - PYTHON_VER='3.5'
+        - STATIC='--static'
+
     - os: osx
       osx_image: xcode7.3
       compiler: clang
@@ -176,91 +73,7 @@ matrix:
         - BUILD_TYPE='release'
         - PYTHON_VER='2.7'
         - HOMEBREW_GCC='homebrew/versions/gcc5'
-    - os: linux
-      compiler: gcc
-      addons: &6
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - boost-latest
-            - george-edison55-precise-backports
-          packages:
-            - cmake
-            - cmake-data
-            - g++-4.7
-            - gcc-4.7
-            - libboost1.55-all-dev
-            - gfortran-4.7
-      env:
-        - CXX_COMPILER='g++-4.7'
-        - C_COMPILER='gcc-4.7'
-        - Fortran_COMPILER='gfortran-4.7'
-        - BUILD_TYPE='release'
         - STATIC='--static'
-        - PYTHON_VER='3.5'
-    - os: osx
-      osx_image: xcode7.3
-      compiler: gcc
-      env:
-        - CXX_COMPILER='g++-5'
-        - C_COMPILER='gcc-5'
-        - Fortran_COMPILER='gfortran-5'
-        - BUILD_TYPE='release'
-        - PYTHON_VER='2.7'
-        - HOMEBREW_GCC='homebrew/versions/gcc5'
-        - STATIC='--static'
-    - os: linux
-      compiler: gcc
-      addons: &7
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - boost-latest
-            - george-edison55-precise-backports
-          packages:
-            - cmake
-            - cmake-data
-            - g++-4.8
-            - gcc-4.8
-            - libboost1.55-all-dev
-            - gfortran-4.8
-      env:
-        - CXX_COMPILER='g++-4.8'
-        - C_COMPILER='gcc-4.8'
-        - Fortran_COMPILER='gfortran-4.8'
-        - BUILD_TYPE='release'
-        - PYTHON_VER='2.7'
-    - os: osx
-      osx_image: xcode7.3
-      compiler: clang
-      env:
-        - CXX_COMPILER='clang++'
-        - C_COMPILER='clang'
-        - Fortran_COMPILER='gfortran-6'
-        - BUILD_TYPE='release'
-        - PYTHON_VER='3.5'
-        - HOMEBREW_GCC='homebrew/versions/gcc6'
-    - os: linux
-      compiler: gcc
-      addons: &8
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - boost-latest
-            - george-edison55-precise-backports
-          packages:
-            - cmake
-            - cmake-data
-            - g++-4.9
-            - gcc-4.9
-            - libboost1.55-all-dev
-            - gfortran-4.9
-      env:
-        - CXX_COMPILER='g++-4.9'
-        - C_COMPILER='gcc-4.9'
-        - Fortran_COMPILER='gfortran-4.9'
-        - BUILD_TYPE='release'
-        - PYTHON_VER='3.5'
     - os: osx
       osx_image: xcode7.3
       compiler: gcc
@@ -271,48 +84,28 @@ matrix:
         - BUILD_TYPE='release'
         - PYTHON_VER='3.5'
         - HOMEBREW_GCC='homebrew/versions/gcc6'
+
     - os: linux
       compiler: gcc
-      addons: &9
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - boost-latest
-            - george-edison55-precise-backports
-          packages:
-            - cmake
-            - cmake-data
-            - g++-5
-            - gcc-5
-            - libboost1.55-all-dev
-            - gfortran-5
+      addons: *1
       env:
-        - CXX_COMPILER='g++-5'
-        - C_COMPILER='gcc-5'
-        - Fortran_COMPILER='gfortran-5'
+        - CXX_COMPILER='g++-4.6'
+        - C_COMPILER='gcc-4.6'
+        - Fortran_COMPILER='gfortran-4.6'
         - BUILD_TYPE='release'
         - PYTHON_VER='2.7'
-    - os: linux
-      compiler: gcc
-      addons: *9
-      env:
-        - CXX_COMPILER='g++-5'
-        - C_COMPILER='gcc-5'
-        - Fortran_COMPILER='gfortran-5'
-        - BUILD_TYPE='release'
         - COVERAGE='--coverage'
-        - PYTHON_VER='2.7'
   allow_failures:
     - os: linux
       compiler: gcc
-      addons: *9
+      addons: *1
       env:
-        - CXX_COMPILER='g++-5'
-        - C_COMPILER='gcc-5'
-        - Fortran_COMPILER='gfortran-5'
+        - CXX_COMPILER='g++-4.6'
+        - C_COMPILER='gcc-4.6'
+        - Fortran_COMPILER='gfortran-4.6'
         - BUILD_TYPE='release'
-        - COVERAGE='--coverage'
         - PYTHON_VER='2.7'
+        - COVERAGE='--coverage'
 install:
 - |
   if [[ "${PYTHON_VER}" == "2.7" ]]; then
@@ -342,17 +135,15 @@ before_script:
 - python -V
 - cmake --version
 - cd ${TRAVIS_BUILD_DIR}
-- export CXX=${CXX_COMPILER}
+- echo 'Build set up summary'
 - ${CXX_COMPILER} --version
-- export CC=${C_COMPILER}
 - ${C_COMPILER} --version
-- export FC=${Fortran_COMPILER}
 - ${Fortran_COMPILER} --version
 - python setup.py --cxx=${CXX_COMPILER} --cc=${C_COMPILER} --fc=${Fortran_COMPILER} --type=${BUILD_TYPE} --cmake-options='-Hprojects/CMake' ${STATIC} ${COVERAGE}
 - cd build
 - ../.scripts/ci_build.sh
 script:
-- python ../.scripts/ci_test.py ctest --parallel 2 --output-on-failure --verbose --dashboard Experimental --track TravisCI
+- python ../.scripts/ci_test.py ctest --output-on-failure --verbose
 - python ../.scripts/ci_print_failing.py
 after_success:
 - |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Continuous integration builds
 
 All CI builds are triggered by push events to any branch.
 Travis CI runs release builds using [ccache](https://ccache.samba.org/) to speed up compilation.
-The outcome of the CI builds is deployed to the [build dashboard](https://testboard.org/cdash/index.php?project=PCMSolver)
 
 - Ubuntu 12.04 LTS 64-bit with CMake 3.3.2 and Boost 1.55.0 this is the
   environment offered by [Travis CI](https://travis-ci.org) pulling in various
@@ -37,29 +36,21 @@ The outcome of the CI builds is deployed to the [build dashboard](https://testbo
   an environment defined in the `.pcmsolver-travis.yml` file. The following
   compilers are used:
 
-  1. GCC 4.6, Python 2.7
-  2. GCC 4.7, Python 3.5
-  3. GCC 4.8, Python 2.7
-  4. GCC 4.9, Python 3.5
-  5. GCC 5.1, Python 2.7, with and without coverage analysis
-  6. Clang 3.5, GFortran 4.6, Python 2.7
-  7. Clang 3.6, GFortran 4.6, Python 3.5
-  8. Clang 3.7, GFortran 4.6, Python 2.7
-  9. Clang 3.8, GFortran 4.6, Python 3.5
+  1. GCC 4.6, Python 2.7 This build generates _both_ the shared and static
+     libraries, linking executables to the former. The build is run with and
+     without coverage analysis.
+  2. Clang 3.5, GFortran 4.6, Python 3.5 This build generates _only_ the static
+     library.
 
 - Mac OS X 10.11 with CMake 3.6.2 and Boost 1.61.0
   this is the environment offered by [Travis CI](https://travis-ci.org)
   with their Xcode 7.3.1 image.
   The following compilers are used:
 
-  1. Apple LLVM 7.3.0, GFortran 4.8.5, Python 2.7
-  2. GCC 4.8.5, Python 2.7
-  3. Apple LLVM 7.3.0, GFortran 4.9.3, Python 3.5
-  4. GCC 4.9.3, Python 3.5
-  5. Apple LLVM 7.3.0, GFortran 5.4.0, Python 2.7
-  6. GCC 5.4.0, Python 2.7
-  7. Apple LLVM 7.3.0, GFortran 6.2.0, Python 3.5
-  8. GCC 6.2.0, Python 3.5
+  1. Apple LLVM 7.3.0, GFortran 5.4.0, Python 2.7 This build generates _only_
+     the static library.
+  2. GCC 6.2.0, Python 3.5 This build generates _both_ the shared and static
+     libraries, linking executables to the former.
 
 The build needed for submission to [Coverity scan](https://scan.coverity.com/)
 is triggered by pushes to the `coverity_scan` branch. It is run on


### PR DESCRIPTION
In order to speed up check times on PRs, a significant number of builds have been removed from `.travis.yml`.
The _rationale_ is that we want to test the oldest supported compilers on Linux and fairly recent compilers on Mac OS X, where it is easier to get update versions of the build toolchain.

## Description
<!--- Describe your changes in detail -->
As documented in the `README.md` the following have been left:
- Ubuntu 12.04 LTS 64-bit with CMake 3.3.2 and Boost 1.55.0 this is the
  environment offered by [Travis CI](https://travis-ci.org) pulling in various
  PPA. Python and Python packages are installed and managed _via_ Conda within
  an environment defined in the `.pcmsolver-travis.yml` file. The following
  compilers are used:

  1. GCC 4.6, Python 2.7 This build generates _both_ the shared and static
     libraries, linking executables to the former. The build is run with and
     without coverage analysis.
  2. Clang 3.5, GFortran 4.6, Python 3.5 This build generates _only_ the static
     library.

- Mac OS X 10.11 with CMake 3.6.2 and Boost 1.61.0
  this is the environment offered by [Travis CI](https://travis-ci.org)
  with their Xcode 7.3.1 image.
  The following compilers are used:

  1. Apple LLVM 7.3.0, GFortran 5.4.0, Python 2.7 This build generates _only_
     the static library.
  2. GCC 6.2.0, Python 3.5 This build generates _both_ the shared and static
     libraries, linking executables to the former.

## Todos
<!--- Notable points that this PR has either accomplished or will accomplish. -->
* **Developer Interest**
<!--- Changes affecting developers -->
  - [x] Leaner Travis CI build menu.
  - [x] Code is now tested serially. This should hopefully the annoying, nondeterministic failures on OS X.
  - [x] Build reports *not sent* to dashboard anymore.

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go


