### PR TITLE
Switch to Ubuntu Trusty Linux image on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 sudo: false
+dist: trusty
 notifications:
   slack:
     secure: F2nQIW6SiaGdw1LjuZOlgBu8rUVMllrDG/5bhmTQP7gyETfViFBjTsHQdTle6jtdb+LudleZaG7WhdEiVcKUa834rKqDk1UOt9p6bsmgbsBZBAaxmPh01iVFhKn3ML7JLjfr1YtH7MWJcsS60cNBrohXfVKfFzNgDqZEu/llr90=
@@ -20,20 +21,15 @@ branches:
 matrix:
   include:
     - os: linux
-      compiler: gcc
       addons: &1
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - boost-latest
-            - george-edison55-precise-backports
           packages:
-            - cmake
-            - cmake-data
+            - cmake3
+            - cmake3-data
             - g++-4.6
             - gcc-4.6
-            - libboost1.55-all-dev
             - gfortran-4.6
+            - libboost-math-dev
       env:
         - CXX_COMPILER='g++-4.6'
         - C_COMPILER='gcc-4.6'
@@ -41,31 +37,24 @@ matrix:
         - BUILD_TYPE='release'
         - PYTHON_VER='2.7'
     - os: linux
-      compiler: clang
       addons:
         apt:
-          sources:
-            - llvm-toolchain-precise-3.5
-            - ubuntu-toolchain-r-test
-            - boost-latest
-            - george-edison55-precise-backports
           packages:
-            - cmake
-            - cmake-data
-            - clang-3.5
-            - libboost1.55-all-dev
-            - gfortran
+            - cmake3
+            - cmake3-data
+            - clang
+            - gfortran-4.6
+            - libboost-math-dev
       env:
-        - CXX_COMPILER='clang++-3.5'
-        - C_COMPILER='clang-3.5'
-        - Fortran_COMPILER='gfortran'
+        - CXX_COMPILER='clang++'
+        - C_COMPILER='clang'
+        - Fortran_COMPILER='gfortran-4.6'
         - BUILD_TYPE='release'
         - PYTHON_VER='3.5'
         - STATIC='--static'
 
     - os: osx
       osx_image: xcode7.3
-      compiler: clang
       env:
         - CXX_COMPILER='clang++'
         - C_COMPILER='clang'
@@ -76,7 +65,6 @@ matrix:
         - STATIC='--static'
     - os: osx
       osx_image: xcode7.3
-      compiler: gcc
       env:
         - CXX_COMPILER='g++-6'
         - C_COMPILER='gcc-6'
@@ -86,24 +74,22 @@ matrix:
         - HOMEBREW_GCC='homebrew/versions/gcc6'
 
     - os: linux
-      compiler: gcc
       addons: *1
       env:
         - CXX_COMPILER='g++-4.6'
         - C_COMPILER='gcc-4.6'
         - Fortran_COMPILER='gfortran-4.6'
-        - BUILD_TYPE='release'
+        - BUILD_TYPE='debug'
         - PYTHON_VER='2.7'
         - COVERAGE='--coverage'
   allow_failures:
     - os: linux
-      compiler: gcc
       addons: *1
       env:
         - CXX_COMPILER='g++-4.6'
         - C_COMPILER='gcc-4.6'
         - Fortran_COMPILER='gfortran-4.6'
-        - BUILD_TYPE='release'
+        - BUILD_TYPE='debug'
         - PYTHON_VER='2.7'
         - COVERAGE='--coverage'
 install:

--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ Continuous integration builds
 All CI builds are triggered by push events to any branch.
 Travis CI runs release builds using [ccache](https://ccache.samba.org/) to speed up compilation.
 
-- Ubuntu 12.04 LTS 64-bit with CMake 3.3.2 and Boost 1.55.0 this is the
-  environment offered by [Travis CI](https://travis-ci.org) pulling in various
-  PPA. Python and Python packages are installed and managed _via_ Conda within
+- Ubuntu 14.04 LTS 64-bit with CMake 3.5.1 and Boost 1.54.0 this is the
+  environment offered by [Travis CI](https://travis-ci.org).
+  Python and Python packages are installed and managed _via_ Conda within
   an environment defined in the `.pcmsolver-travis.yml` file. The following
   compilers are used:
 
   1. GCC 4.6, Python 2.7 This build generates _both_ the shared and static
      libraries, linking executables to the former. The build is run with and
-     without coverage analysis.
+     without coverage analysis, the latter being a _debug_ build.
   2. Clang 3.5, GFortran 4.6, Python 3.5 This build generates _only_ the static
      library.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Use labels to help the developers -->
<!--- Remove the unnecessary sections when filing -->
As per this [blog post](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming) the Travis Linux infrastructure will move to Ubuntu Trusty images. 

## Todos
<!--- Notable points that this PR has either accomplished or will accomplish. -->
* **Developer Interest**
<!--- Changes affecting developers -->
  - [x] Explicitly use Trusty image in .travis.yml
  - [x] Clean up list of dependencies to be installed


## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go

