### PR TITLE
Forward stdout and stderr from Python to terminal

### DIFF
--- a/tools/pcmsolver.py.in
+++ b/tools/pcmsolver.py.in
@@ -189,11 +189,18 @@ def parse_pcm_input(inputFile):
 def execute(parsedFile):
     executable = os.path.join(os.path.dirname(__file__), "run_pcm" + "@CMAKE_EXECUTABLE_SUFFIX@")
     if (executable):
-        try:
-            subprocess.check_output([executable, parsedFile])
-        except subprocess.CalledProcessError as e:
-            print((e.output))
-            sys.exit(1)
+        p = subprocess.Popen([executable, parsedFile],
+                             shell=False,
+                             stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        stdout_coded, stderr_coded = p.communicate()
+        stdout = stdout_coded.decode('UTF-8')
+        stderr = stderr_coded.decode('UTF-8')
+
+        print(stdout)
+        # Print the contents of stderr, without exiting
+        sys.stderr.write(stderr)
     else:
         print('No executable available for standalone run')
         sys.exit(1)


### PR DESCRIPTION
This PR fixes the handling of `stdout` and `stderr` in the Python script.

## Description
When executing `run_pcm` as a `subprocess` in the Python parsing script, `stdout` and `stderr` are now communicated onwards after execution. This means that using `std::cout`, `std::printf` and `std::cerr` will result in stuff being printed to the terminal, as expected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@ilfreddy noticed that adding `std::cout` in the C++ code didn't result in anything printed to the terminal when executing standalone. A situation that was not occurring when the Python wrapper was used only for input parsing and execution was done calling `run_pcm` by hand.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have run the code adding some `std::cout`, `std::printf` and `std::cerr` calls. Everything is output as expected.

## Todos
<!--- Notable points that this PR has either accomplished or will accomplish. -->
  - [x] Correctly propagate `stdout` and `stderr` also when calling `run_pcm` from the Python script.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go


