### PR TITLE
Use #pragma once instead of preprocessor guards

### DIFF
--- a/.githooks/license_maintainer.py
+++ b/.githooks/license_maintainer.py
@@ -23,11 +23,11 @@ variables YEAR and AUTHORS. The latter has to be modified by hand.
 
 from datetime import date
 import glob
-import mmap
 import os
 import re
 import shutil
 import tempfile
+
 
 def add_header(filepath, header, YEAR, AUTHORS):
     """
@@ -36,26 +36,26 @@ def add_header(filepath, header, YEAR, AUTHORS):
     tmpdir = tempfile.gettempdir()
     tmpfil = os.path.join(tmpdir, os.path.basename(filepath) + '.bak')
     shutil.copy2(filepath, tmpfil)
-    with open(tmpfil, 'r+b') as tmp:
+    with open(tmpfil, 'r') as tmp:
         inpt = tmp.readlines()
         output = []
 
         # Check if header is already present
         present = re.compile('PCMSolver, an API for the Polarizable Continuum Model')
-        if filter(present.search, inpt):
+        if list(filter(present.search, inpt)):
             # Check if year and authors in current file are up to date
             toupdate = re.compile(r'{0} (?!{1} {2}).*\n'.format('Copyright \(C\)', YEAR, AUTHORS))
-            if filter(toupdate.search, inpt):
-                print('Updating header in {}'.format(filepath))
+            if list(filter(toupdate.search, inpt)):
+                print(('Updating header in {}'.format(filepath)))
                 # Check to preserve '#!' at the top of the file
                 if len(inpt) > 0 and inpt[0].startswith('#!'):
                     output.append(inpt[0] + '\n')
                     inpt = inpt[1:]
                 regex = re.compile(r'Copyright \(C\).*\n')
                 repl  = r'Copyright (C) ' + YEAR + ' ' + AUTHORS + '\n'
-                output.extend(map(lambda x: re.sub(regex, repl, x), inpt))
+                output.extend([re.sub(regex, repl, x) for x in inpt])
         else:
-            print('Adding header in {}'.format(filepath))
+            print(('Adding header in {}'.format(filepath)))
             # Check to preserve '#!' at the top of the file
             if len(inpt) > 0 and inpt[0].startswith('#!'):
                 output.append(inpt[0] + '\n')
@@ -68,8 +68,8 @@ def add_header(filepath, header, YEAR, AUTHORS):
             try:
                 f = open(filepath, 'w')
                 f.writelines(output)
-            except IOError, err:
-                print('Something went wrong trying to add header to {}: {}'.format(filepath, err))
+            except IOError as err:
+                print(('Something went wrong trying to add header to {}: {}'.format(filepath, err)))
             finally:
                 f.close()
         os.remove(tmpfil)
@@ -79,12 +79,12 @@ def prepare_header(stub, YEAR, AUTHORS):
     """
     Update year and author information in license header template
     """
-    with open(stub, 'r+b') as l:
+    with open(stub, 'r') as l:
         header = l.read()
         # Insert correct YEAR and AUTHORS in stub
         rep = {'YEAR' : YEAR, 'AUTHORS' : AUTHORS}
-        rep = dict((re.escape(k), v) for k, v in rep.iteritems())
-        pattern = re.compile("|".join(rep.keys()))
+        rep = dict((re.escape(k), v) for k, v in rep.items())
+        pattern = re.compile("|".join(list(rep.keys())))
         header = pattern.sub(lambda m: rep[re.escape(m.group(0))], header)
     return header
 
@@ -94,26 +94,26 @@ def file_license(attributes):
     Obtain dictionary { file : license } from .gitattributes
     """
     file_license = {}
-    with open(attributes, 'r+b') as f:
+    with open(attributes, 'r') as f:
         # Read in .gitattributes
-        tmp_mm = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
+        tmp = f.read()
         # Removing all comment lines and other attributes
-        pattern = re.compile("|".join([r'(?m)^\#.*\n?', r'^((?!licensefile).)*$']))
-        gitattributes = re.sub(pattern, '', tmp_mm).split()
+        pattern = re.compile(r'(?m)^\#.*\n?|^((?!licensefile).)*$')
+        gitattributes = re.sub(pattern, '', tmp).split()
         # Obtain list of files
         fil = [x for x in gitattributes if not 'licensefile' in x]
         # Remove licensefile= from strings
         lic = [re.sub(r'licensefile\=', '', x) for x in gitattributes if 'licensefile' in x]
         # Create list of blacklisted files
-        blacklist = [fname for key, value in dict(zip(fil, lic)).items()
+        blacklist = [fname for key, value in list(dict(list(zip(fil, lic))).items())
                        if value == '!licensefile'
                        for fname in glob.glob(key)]
         # Now create a dictionary with the files to be considered for
         # license header manipulation
-        file_license = { key : value
-                  for k, value in dict(zip(fil, lic)).items()
-                  for key in glob.glob(k)
-                  if key not in blacklist}
+        file_license = {key: value
+                        for k, value in list(dict(list(zip(fil, lic))).items())
+                        for key in glob.glob(k)
+                        if key not in blacklist}
     return file_license
 
 
@@ -129,7 +129,7 @@ def license_maintainer():
 
     headerize = file_license(os.path.join(project_root_dir, '.gitattributes'))
 
-    for fname, license in headerize.items():
+    for fname, license in list(headerize.items()):
         # Prepare header
         header = prepare_header(os.path.join(project_root_dir, license), YEAR, AUTHORS)
         add_header(fname, header, YEAR, AUTHORS)

--- a/.githooks/pre-commit-clang-format
+++ b/.githooks/pre-commit-clang-format
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # git pre-commit hook that runs an clang-format stylecheck.
 # Features:

--- a/.githooks/pre-commit-license-maintainer
+++ b/.githooks/pre-commit-license-maintainer
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 python .githooks/license_maintainer.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
   of the ASC.
 - Restored compilation for g++ < v5.1.
 
+### Changed
+
+- Use [`#pragma once`](https://en.wikipedia.org/wiki/Pragma_once) instead of
+  `#ifndef, #define, #endif` to guard against multiple inclusion of header
+  files.
+
 ## [Version 1.1.10] - 2017-03-27
 
 ### Changed

--- a/api/PCMInput.h
+++ b/api/PCMInput.h
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef PCMINPUT_H
-#define PCMINPUT_H
+#pragma once
 
 // To cope with the fact that C doesn't have bool as primitive type
 #ifndef pcmsolver_bool_t_DEFINED
@@ -78,5 +77,3 @@ typedef struct PCMInput {
   /// Type of Green's function requested outside the cavity.
   char outside_type[22];
 } PCMInput;
-
-#endif // PCMINPUT_H

--- a/api/pcmsolver.h
+++ b/api/pcmsolver.h
@@ -21,10 +21,10 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef PCMSOLVER_H_INCLUDED
-#define PCMSOLVER_H_INCLUDED
+#pragma once
 
 #include <stddef.h>
+
 #include "PCMInput.h"
 #include "PCMSolverExport.h"
 
@@ -271,5 +271,3 @@ PCMSolver_API void pcmsolver_write_timings(pcmsolver_context_t * context);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* PCMSOLVER_H_INCLUDED */

--- a/doc/programmers/coding-standards.rst
+++ b/doc/programmers/coding-standards.rst
@@ -31,8 +31,7 @@ Follow these guidelines to decide whether to include or forward declare:
 
 .. code-block:: cpp
 
-    #ifndef MYCLASS_HPP
-    #define MYCLASS_HPP
+    #pragma once
 
     //==============================
     // Forward declared dependencies
@@ -56,8 +55,6 @@ Follow these guidelines to decide whether to include or forward declare:
         friend class MyFriend;    // friend declaration is not a dependency
                                   //    don't do anything about MyFriend
     };
-
-    #endif // MYCLASS_HPP
 
 
 Proper overloading of `operator<<`

--- a/include/Citation.hpp
+++ b/include/Citation.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef CITATION_HPP
-#define CITATION_HPP
+#pragma once
 
 #include <algorithm>
 #include <sstream>
@@ -45,7 +44,8 @@ inline std::string citation_message() {
   std::string version(TOSTRING(PROJECT_VERSION));
   rest << "\n" << std::endl;
   rest << " * PCMSolver, an API for the Polarizable Continuum Model electrostatic "
-          "problem. Version " << version << std::endl;
+          "problem. Version "
+       << version << std::endl;
   rest << "   Main authors: R. Di Remigio, L. Frediani, K. Mozgawa" << std::endl;
   rest << "    With contributions from:" << std::endl;
   rest << "     R. Bast            (CMake framework)" << std::endl;
@@ -54,9 +54,11 @@ inline std::string citation_message() {
        << std::endl;
   rest << "   Theory: - J. Tomasi, B. Mennucci and R. Cammi:" << std::endl;
   rest << "            \"Quantum Mechanical Continuum Solvation Models\", Chem. "
-          "Rev., 105 (2005) 2999" << std::endl;
+          "Rev., 105 (2005) 2999"
+       << std::endl;
   rest << "   PCMSolver is distributed under the terms of the GNU Lesser General "
-          "Public License." << std::endl;
+          "Public License."
+       << std::endl;
   return rest.str();
 }
 
@@ -67,5 +69,3 @@ inline std::string version_info() {
   retval << " * Git last commit author : " << GIT_COMMIT_AUTHOR << std::endl;
   return retval.str();
 }
-
-#endif // CITATION_HPP

--- a/include/Cxx11Workarounds.hpp
+++ b/include/Cxx11Workarounds.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef CXX11WORKAROUNDS_HPP
-#define CXX11WORKAROUNDS_HPP
+#pragma once
 
 /*! \file Cxx11Workarounds.hpp
  *  \brief Provide hacks and workarounds for C++11
@@ -73,8 +72,8 @@ using std::to_string;
 } /* end namespace pcm */
 #else /* HAS_CXX11*/
 /* Smart pointers workarounds */
-#include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
 namespace pcm {
 using boost::shared_ptr;
 using boost::make_shared;
@@ -105,8 +104,8 @@ namespace pcm {
 using boost::array;
 } /* end namespace pcm */
 /* std::to_string workarounds */
-#include <string>
 #include <boost/lexical_cast.hpp>
+#include <string>
 namespace pcm {
 template <typename Source> std::string to_string(const Source & arg) {
   return boost::lexical_cast<std::string>(arg);
@@ -153,5 +152,3 @@ template <typename Source> std::string to_string(const Source & arg) {
 #else /* HAS_CXX11_NORETURN */
 #define __noreturn
 #endif /* HAS_CXX11_NORETURN */
-
-#endif /* CXX11WORKAROUNDS_HPP */

--- a/include/ErrorHandling.hpp
+++ b/include/ErrorHandling.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef ERRORHANDLING_HPP
-#define ERRORHANDLING_HPP
+#pragma once
 
 #include <cassert>
 #include <cstdio>
@@ -76,7 +75,8 @@
     std::ostringstream _err;                                                        \
     _err << "PCMSolver fatal error.\n"                                              \
          << " In function " << __func__ << " at line " << __LINE__ << " of file "   \
-         << __FILE__ << "\n" << message << std::endl;                               \
+         << __FILE__ << "\n"                                                        \
+         << message << std::endl;                                                   \
     std::fprintf(stderr, "%s\n", _err.str().c_str());                               \
     std::exit(EXIT_FAILURE);                                                        \
   }
@@ -91,5 +91,3 @@
 #include <boost/static_assert.hpp>
 #define PCMSOLVER_STATIC_ASSERT(arg, msg) BOOST_STATIC_ASSERT_MSG(arg, msg)
 #endif /* HAS_CXX11_STATIC_ASSERT */
-
-#endif /* ERRORHANDLING_HPP */

--- a/include/LoggerInterface.hpp
+++ b/include/LoggerInterface.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef LOGGERINTERFACE_HPP
-#define LOGGERINTERFACE_HPP
+#pragma once
 
 #ifdef ENABLE_LOGGER
 
@@ -46,5 +45,3 @@ static logging::logger<logging::FileLogPolicy> loggerInstance(
 #define LOG_TIME
 
 #endif /* ENABLE_LOGGER */
-
-#endif /* LOGGERINTERFACE_HPP */

--- a/include/PhysicalConstants.hpp
+++ b/include/PhysicalConstants.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef PHYSICALCONSTANTS_HPP
-#define PHYSICALCONSTANTS_HPP
+#pragma once
 
 #include <cmath>
 
@@ -51,5 +50,3 @@ double angstrom2ToBohr2();
 double bohr3ToAngstrom3();
 
 double angstrom3ToBohr3();
-
-#endif // PHYSICALCONSTANTS_HPP

--- a/include/STLUtils.hpp
+++ b/include/STLUtils.hpp
@@ -8,25 +8,25 @@
  * This software is provided "as is" without express or implied
  * warranty, and with no claim as to its suitability for any purpose.
  */
-#ifndef GENERALPURPOSE_HPP
-#define GENERALPURPOSE_HPP
 
-#include <array>
-#include <vector>
-#include <deque>
-#include <list>
-#include <forward_list>
-#include <set>
-#include <map>
-#include <unordered_set>
-#include <unordered_map>
+#pragma once
+
 #include <algorithm>
-#include <iterator>
-#include <functional>
-#include <numeric>
-#include <iostream>
-#include <string>
+#include <array>
+#include <deque>
+#include <forward_list>
 #include <fstream>
+#include <functional>
+#include <iostream>
+#include <iterator>
+#include <list>
+#include <map>
+#include <numeric>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 // INSERT_ELEMENTS (collection, first, last)
 // - fill values from first to last into the collection
@@ -62,5 +62,3 @@ inline void PRINT_MAPPED_ELEMENTS(const T & coll, const std::string & optcstr = 
   }
   std::cout << std::endl;
 }
-
-#endif /*GENERALPURPOSE_HPP*/

--- a/include/TimerInterface.hpp
+++ b/include/TimerInterface.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef TIMERINTERFACE_HPP
-#define TIMERINTERFACE_HPP
+#pragma once
 
 /*  To time a code snippet:
  *  \code{.cpp}
@@ -47,5 +46,3 @@
 #define TIMER_DONE(...)
 
 #endif /* ENABLE_TIMER */
-
-#endif /* TIMERINTERFACE_HPP */

--- a/src/bi_operators/BIOperatorData.hpp
+++ b/src/bi_operators/BIOperatorData.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef BIOPERATORDATA_HPP
-#define BIOPERATORDATA_HPP
+#pragma once
 
 #include "Config.hpp"
 
@@ -41,5 +40,3 @@ struct BIOperatorData {
   BIOperatorData(double s) : scaling(s) { empty = false; }
 };
 } // namespace pcm
-
-#endif // BIOPERATORDATA_HPP

--- a/src/bi_operators/BoundaryIntegralOperator.hpp
+++ b/src/bi_operators/BoundaryIntegralOperator.hpp
@@ -21,16 +21,15 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef BOUNDARYINTEGRALOPERATOR_HPP
-#define BOUNDARYINTEGRALOPERATOR_HPP
+#pragma once
 
 #include "Config.hpp"
 
-#include "IBoundaryIntegralOperator.hpp"
 #include "BIOperatorData.hpp"
 #include "Collocation.hpp"
-#include "Purisima.hpp"
+#include "IBoundaryIntegralOperator.hpp"
 #include "Numerical.hpp"
+#include "Purisima.hpp"
 #include "utils/Factory.hpp"
 
 /*!
@@ -62,5 +61,3 @@ inline Factory<detail::CreateBIOperator> bootstrapFactory() {
 }
 } // namespace bi_operators
 } // namespace pcm
-
-#endif // BOUNDARYINTEGRALOPERATOR_HPP

--- a/src/bi_operators/Collocation.hpp
+++ b/src/bi_operators/Collocation.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef COLLOCATION_HPP
-#define COLLOCATION_HPP
+#pragma once
 
 #include <vector>
 
@@ -78,5 +77,3 @@ private:
 IBoundaryIntegralOperator * createCollocation(const BIOperatorData & data);
 } // namespace bi_operators
 } // namespace pcm
-
-#endif // COLLOCATION_HPP

--- a/src/bi_operators/IBoundaryIntegralOperator.hpp
+++ b/src/bi_operators/IBoundaryIntegralOperator.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef BOUNDARYINTEGRALOPERATORS_HPP
-#define BOUNDARYINTEGRALOPERATORS_HPP
+#pragma once
 
 #include <vector>
 
@@ -52,5 +51,3 @@ private:
                                         const IGreensFunction & gf) const = 0;
 };
 } // namespace pcm
-
-#endif // BOUNDARYINTEGRALOPERATORS_HPP

--- a/src/bi_operators/Numerical.hpp
+++ b/src/bi_operators/Numerical.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef NUMERICAL_HPP
-#define NUMERICAL_HPP
+#pragma once
 
 #include <vector>
 
@@ -73,7 +72,8 @@ typedef pcm::function<double(const Eigen::Vector3d &, const Eigen::Vector3d &)>
  */
 typedef pcm::function<double(const Eigen::Vector3d &,
                              const Eigen::Vector3d &,
-                             const Eigen::Vector3d &)> KernelD;
+                             const Eigen::Vector3d &)>
+    KernelD;
 
 /*! \brief Integrates a single layer type operator on a single spherical polygon
  *  \date 2014
@@ -98,5 +98,3 @@ template <int PhiPoints, int ThetaPoints>
 double integrateD(const KernelD & F, const cavity::Element & e);
 } // namespace bi_operators
 } // namespace pcm
-
-#endif // NUMERICAL_HPP

--- a/src/bi_operators/Purisima.hpp
+++ b/src/bi_operators/Purisima.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef PURISIMA_HPP
-#define PURISIMA_HPP
+#pragma once
 
 #include <vector>
 
@@ -85,5 +84,3 @@ private:
 IBoundaryIntegralOperator * createPurisima(const BIOperatorData & data);
 } // namespace bi_operators
 } // namespace pcm
-
-#endif // PURISIMA_HPP

--- a/src/cavity/Cavity.hpp
+++ b/src/cavity/Cavity.hpp
@@ -21,13 +21,12 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef CAVITY_HPP
-#define CAVITY_HPP
+#pragma once
 
 #include "Config.hpp"
 
-#include "ICavity.hpp"
 #include "GePolCavity.hpp"
+#include "ICavity.hpp"
 #include "RestartCavity.hpp"
 #include "utils/Factory.hpp"
 
@@ -57,5 +56,3 @@ inline Factory<detail::CreateCavity> bootstrapFactory() {
 }
 } // namespace cavity
 } // namespace pcm
-
-#endif // CAVITY_HPP

--- a/src/cavity/CavityData.hpp
+++ b/src/cavity/CavityData.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef CAVITYDATA_HPP
-#define CAVITYDATA_HPP
+#pragma once
 
 #include <string>
 
@@ -87,5 +86,3 @@ struct CavityData {
   }
 };
 } // namespace pcm
-
-#endif // CAVITYDATA_HPP

--- a/src/cavity/Element.hpp
+++ b/src/cavity/Element.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef ELEMENT_HPP
-#define ELEMENT_HPP
+#pragma once
 
 #include <ostream>
 #include <vector>
@@ -139,5 +138,3 @@ void tangent_and_bitangent(const Eigen::Vector3d & n_,
 } // namespace detail
 } // namespace cavity
 } // namespace pcm
-
-#endif // ELEMENT_HPP

--- a/src/cavity/GePolCavity.hpp
+++ b/src/cavity/GePolCavity.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef GEPOLCAVITY_HPP
-#define GEPOLCAVITY_HPP
+#pragma once
 
 #include <iosfwd>
 #include <string>
@@ -182,5 +181,3 @@ extern "C" void generatecavity_cpp(int * maxts,
 ICavity * createGePolCavity(const CavityData & data);
 } // namespace cavity
 } // namespace pcm
-
-#endif // GEPOLCAVITY_HPP

--- a/src/cavity/ICavity.hpp
+++ b/src/cavity/ICavity.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef ICAVITY_HPP
-#define ICAVITY_HPP
+#pragma once
 
 #include <iosfwd>
 #include <vector>
@@ -169,5 +168,3 @@ public:
   }
 };
 } // namespace pcm
-
-#endif // ICAVITY_HPP

--- a/src/cavity/RestartCavity.hpp
+++ b/src/cavity/RestartCavity.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef RESTARTCAVITY_HPP
-#define RESTARTCAVITY_HPP
+#pragma once
 
 #include <iosfwd>
 #include <string>
@@ -61,5 +60,3 @@ private:
 ICavity * createRestartCavity(const CavityData & data);
 } // namespace cavity
 } // namespace pcm
-
-#endif // RESTARTCAVITY_HPP

--- a/src/green/AnisotropicLiquid.hpp
+++ b/src/green/AnisotropicLiquid.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef ANISOTROPICLIQUID_HPP
-#define ANISOTROPICLIQUID_HPP
+#pragma once
 
 #include <iosfwd>
 
@@ -99,5 +98,3 @@ struct buildAnisotropicLiquid {
 IGreensFunction * createAnisotropicLiquid(const GreenData & data);
 } // namespace green
 } // namespace pcm
-
-#endif // ANISOTROPICLIQUID_HPP

--- a/src/green/DerivativeTypes.hpp
+++ b/src/green/DerivativeTypes.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef DERIVATIVETYPES_HPP
-#define DERIVATIVETYPES_HPP
+#pragma once
 
 #include "Config.hpp"
 
@@ -41,5 +40,3 @@ typedef boost::mpl::vector<Stencil, AD_directional, AD_gradient, AD_hessian>
     derivative_types;
 } // namespace green
 } // namespace pcm
-
-#endif // DERIVATIVETYPES_HPP

--- a/src/green/DerivativeUtils.hpp
+++ b/src/green/DerivativeUtils.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef DERIVATIVEUTILS_HPP
-#define DERIVATIVEUTILS_HPP
+#pragma once
 
 #include "Config.hpp"
 
@@ -40,5 +39,3 @@ template <typename DerivativeTraits>
 inline DerivativeTraits dot_product(DerivativeTraits u[3], DerivativeTraits v[3]) {
   return (u[0] * v[0] + u[1] * v[1] + u[2] * v[2]);
 }
-
-#endif // DERIVATIVEUTILS_HPP

--- a/src/green/Green.hpp
+++ b/src/green/Green.hpp
@@ -21,18 +21,17 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef GREEN_HPP
-#define GREEN_HPP
+#pragma once
 
 #include "Config.hpp"
 
-#include "IGreensFunction.hpp"
-#include "GreenData.hpp"
-#include "Vacuum.hpp"
-#include "UniformDielectric.hpp"
 #include "AnisotropicLiquid.hpp"
+#include "GreenData.hpp"
+#include "IGreensFunction.hpp"
 #include "IonicLiquid.hpp"
 #include "SphericalDiffuse.hpp"
+#include "UniformDielectric.hpp"
+#include "Vacuum.hpp"
 #include "utils/Factory.hpp"
 
 /*!
@@ -64,5 +63,3 @@ inline Factory<detail::CreateGreensFunction> bootstrapFactory() {
 }
 } // namespace green
 } // namespace pcm
-
-#endif // GREEN_HPP

--- a/src/green/GreenData.hpp
+++ b/src/green/GreenData.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef GREENDATA_HPP
-#define GREENDATA_HPP
+#pragma once
 
 #include <vector>
 
@@ -112,5 +111,3 @@ struct GreenData {
                                      */
 };
 } // namespace pcm
-
-#endif // GREENDATA_HPP

--- a/src/green/GreenUtils.hpp
+++ b/src/green/GreenUtils.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef GREENUTILS_HPP
-#define GREENUTILS_HPP
+#pragma once
 
 #include "Config.hpp"
 
@@ -156,7 +155,8 @@ Eigen::Vector3d gradientSource(
   return (Eigen::Vector3d() << derivativeSource(
               functor, Eigen::Vector3d::UnitX(), p1, p2),
           derivativeSource(functor, Eigen::Vector3d::UnitY(), p1, p2),
-          derivativeSource(functor, Eigen::Vector3d::UnitZ(), p1, p2)).finished();
+          derivativeSource(functor, Eigen::Vector3d::UnitZ(), p1, p2))
+      .finished();
 }
 
 /*! Returns full gradient of the function passed for the pair of points p1, p2:
@@ -177,7 +177,8 @@ Eigen::Vector3d gradientProbe(
   return (Eigen::Vector3d() << derivativeProbe(
               functor, Eigen::Vector3d::UnitX(), p1, p2),
           derivativeProbe(functor, Eigen::Vector3d::UnitY(), p1, p2),
-          derivativeProbe(functor, Eigen::Vector3d::UnitZ(), p1, p2)).finished();
+          derivativeProbe(functor, Eigen::Vector3d::UnitZ(), p1, p2))
+      .finished();
 }
 
 /*! Returns full gradient of the function passed for the pair of points p1, p2:
@@ -194,7 +195,8 @@ Eigen::Vector3d gradientSource(const DifferentiableFunction & functor,
   return (Eigen::Vector3d() << derivativeSource(
               functor, Eigen::Vector3d::UnitX(), p1, p2),
           derivativeSource(functor, Eigen::Vector3d::UnitY(), p1, p2),
-          derivativeSource(functor, Eigen::Vector3d::UnitZ(), p1, p2)).finished();
+          derivativeSource(functor, Eigen::Vector3d::UnitZ(), p1, p2))
+      .finished();
 }
 
 /*! Returns full gradient of the function passed for the pair of points p1, p2:
@@ -211,8 +213,7 @@ Eigen::Vector3d gradientProbe(const DifferentiableFunction & functor,
   return (Eigen::Vector3d() << derivativeProbe(
               functor, Eigen::Vector3d::UnitX(), p1, p2),
           derivativeProbe(functor, Eigen::Vector3d::UnitY(), p1, p2),
-          derivativeProbe(functor, Eigen::Vector3d::UnitZ(), p1, p2)).finished();
+          derivativeProbe(functor, Eigen::Vector3d::UnitZ(), p1, p2))
+      .finished();
 }
 } // namespace green
-
-#endif // GREENUTILS_HPP

--- a/src/green/GreensFunction.hpp
+++ b/src/green/GreensFunction.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef GREENSFUNCTION_HPP
-#define GREENSFUNCTION_HPP
+#pragma once
 
 #include <cmath>
 #include <iosfwd>
@@ -115,7 +114,8 @@ public:
                                  const Eigen::Vector3d & p2) const {
     return (Eigen::Vector3d() << derivativeSource(Eigen::Vector3d::UnitX(), p1, p2),
             derivativeSource(Eigen::Vector3d::UnitY(), p1, p2),
-            derivativeSource(Eigen::Vector3d::UnitZ(), p1, p2)).finished();
+            derivativeSource(Eigen::Vector3d::UnitZ(), p1, p2))
+        .finished();
   }
   /*! Returns full gradient of Greens's function for the pair of points p1, p2:
    *  \f$ \nabla_{\mathbf{p_2}}G(\mathbf{p}_1, \mathbf{p}_2)\f$
@@ -127,7 +127,8 @@ public:
                                 const Eigen::Vector3d & p2) const {
     return (Eigen::Vector3d() << derivativeProbe(Eigen::Vector3d::UnitX(), p1, p2),
             derivativeProbe(Eigen::Vector3d::UnitY(), p1, p2),
-            derivativeProbe(Eigen::Vector3d::UnitZ(), p1, p2)).finished();
+            derivativeProbe(Eigen::Vector3d::UnitZ(), p1, p2))
+        .finished();
   }
   /**@}*/
 
@@ -246,7 +247,8 @@ public:
                                  const Eigen::Vector3d & p2) const {
     return (Eigen::Vector3d() << derivativeSource(Eigen::Vector3d::UnitX(), p1, p2),
             derivativeSource(Eigen::Vector3d::UnitY(), p1, p2),
-            derivativeSource(Eigen::Vector3d::UnitZ(), p1, p2)).finished();
+            derivativeSource(Eigen::Vector3d::UnitZ(), p1, p2))
+        .finished();
   }
   /*! Returns full gradient of Greens's function for the pair of points p1, p2:
    *  \f$ \nabla_{\mathbf{p_2}}G(\mathbf{p}_1, \mathbf{p}_2)\f$
@@ -258,7 +260,8 @@ public:
                                 const Eigen::Vector3d & p2) const {
     return (Eigen::Vector3d() << derivativeProbe(Eigen::Vector3d::UnitX(), p1, p2),
             derivativeProbe(Eigen::Vector3d::UnitY(), p1, p2),
-            derivativeProbe(Eigen::Vector3d::UnitZ(), p1, p2)).finished();
+            derivativeProbe(Eigen::Vector3d::UnitZ(), p1, p2))
+        .finished();
   }
   /**@}*/
 
@@ -344,5 +347,3 @@ inline double diagonalDi(double area, double radius, double factor) {
 } // namespace detail
 } // namespace green
 } // namespace pcm
-
-#endif // GREENSFUNCTION_HPP

--- a/src/green/IGreensFunction.hpp
+++ b/src/green/IGreensFunction.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef IGREENSFUNCTION_HPP
-#define IGREENSFUNCTION_HPP
+#pragma once
 
 #include <iosfwd>
 #include <vector>
@@ -74,7 +73,8 @@ typedef function<double(const Eigen::Vector3d &, const Eigen::Vector3d &)> Kerne
  */
 typedef pcm::function<double(const Eigen::Vector3d &,
                              const Eigen::Vector3d &,
-                             const Eigen::Vector3d &)> KernelD;
+                             const Eigen::Vector3d &)>
+    KernelD;
 
 /*! \typedef DerivativeProbe
  *  \brief functor handle to the derivativeProbe method
@@ -82,7 +82,8 @@ typedef pcm::function<double(const Eigen::Vector3d &,
  */
 typedef pcm::function<double(const Eigen::Vector3d &,
                              const Eigen::Vector3d &,
-                             const Eigen::Vector3d &)> DerivativeProbe;
+                             const Eigen::Vector3d &)>
+    DerivativeProbe;
 
 class IGreensFunction {
 public:
@@ -211,5 +212,3 @@ protected:
   virtual std::ostream & printObject(std::ostream & os) = 0;
 };
 } // namespace pcm
-
-#endif // IGREENSFUNCTION_HPP

--- a/src/green/InterfacesImpl.hpp
+++ b/src/green/InterfacesImpl.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef INTERFACESIMPL_HPP
-#define INTERFACESIMPL_HPP
+#pragma once
 
 #include <cmath>
 #include <fstream>
@@ -150,8 +149,11 @@ public:
                  double rinf,
                  const ProfileEvaluator & eval,
                  const IntegratorParameters & parms)
-      : solution_(IndependentSolution<StateVariable,
-                                      ODESystem>(l, r0, rinf, eval, parms)) {}
+      : solution_(IndependentSolution<StateVariable, ODESystem>(l,
+                                                                r0,
+                                                                rinf,
+                                                                eval,
+                                                                parms)) {}
   ~RadialFunction() {}
   /*! \brief Returns value of function and its first derivative at given point
    *  \param[in] point evaluation point
@@ -405,5 +407,3 @@ void writeToFile(RadialFunction<StateVariable, ODESystem, IndependentSolution> &
 }
 } // namespace green
 } // namespace pcm
-
-#endif // INTERFACESIMPL_HPP

--- a/src/green/IonicLiquid.hpp
+++ b/src/green/IonicLiquid.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef IONICLIQUID_HPP
-#define IONICLIQUID_HPP
+#pragma once
 
 #include <iosfwd>
 
@@ -95,5 +94,3 @@ struct buildIonicLiquid {
 IGreensFunction * createIonicLiquid(const GreenData & data);
 } // namespace green
 } // namespace pcm
-
-#endif // IONICLIQUID_HPP

--- a/src/green/SphericalDiffuse.hpp
+++ b/src/green/SphericalDiffuse.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef SPHERICALDIFFUSE_HPP
-#define SPHERICALDIFFUSE_HPP
+#pragma once
 
 #include <iosfwd>
 
@@ -39,9 +38,9 @@ class OneLayerTanh;
 } // namespace dielectric_profile
 } // namespace pcm
 
-#include "InterfacesImpl.hpp"
 #include "GreenData.hpp"
 #include "GreensFunction.hpp"
+#include "InterfacesImpl.hpp"
 
 /*! \file SphericalDiffuse.hpp
  *  \class SphericalDiffuse
@@ -273,5 +272,3 @@ struct buildSphericalDiffuse {
 IGreensFunction * createSphericalDiffuse(const GreenData & data);
 } // namespace green
 } // namespace pcm
-
-#endif // SPHERICALDIFFUSE_HPP

--- a/src/green/SphericalSharp.hpp
+++ b/src/green/SphericalSharp.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef SPHERICALSHARP_HPP
-#define SPHERICALSHARP_HPP
+#pragma once
 
 #include <cmath>
 #include <iosfwd>
@@ -34,11 +33,11 @@
 
 #include "DerivativeTypes.hpp"
 #include "DerivativeUtils.hpp"
-#include "bi_operators/IntegratorForward.hpp"
 #include "GreensFunction.hpp"
-#include "utils/legendre.h"
-#include "utils/MathUtils.hpp"
+#include "bi_operators/IntegratorForward.hpp"
 #include "dielectric_profile/Sharp.hpp"
+#include "utils/MathUtils.hpp"
+#include "utils/legendre.h"
 
 /*! \file SphericalSharp.hpp
  *  \class SphericalSharp
@@ -249,5 +248,3 @@ public:
     return os;
   }
 };
-
-#endif // SPHERICALSHARP_HPP

--- a/src/green/UniformDielectric.hpp
+++ b/src/green/UniformDielectric.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef UNIFORMDIELECTRIC_HPP
-#define UNIFORMDIELECTRIC_HPP
+#pragma once
 
 #include <iosfwd>
 
@@ -93,5 +92,3 @@ struct buildUniformDielectric {
 IGreensFunction * createUniformDielectric(const GreenData & data);
 } // namespace green
 } // namespace pcm
-
-#endif // UNIFORMDIELECTRIC_HPP

--- a/src/green/Vacuum.hpp
+++ b/src/green/Vacuum.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef VACUUM_HPP
-#define VACUUM_HPP
+#pragma once
 
 #include <iosfwd>
 
@@ -95,5 +94,3 @@ struct buildVacuum {
 IGreensFunction * createVacuum(const GreenData & data);
 } // namespace green
 } // namespace pcm
-
-#endif // VACUUM_HPP

--- a/src/green/dielectric_profile/Anisotropic.hpp
+++ b/src/green/dielectric_profile/Anisotropic.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef ANISOTROPIC_HPP
-#define ANISOTROPIC_HPP
+#pragma once
 
 #include <iosfwd>
 
@@ -102,5 +101,3 @@ public:
 };
 } // namespace dielectric_profile
 } // namespace pcm
-
-#endif // ANISOTROPIC_HPP

--- a/src/green/dielectric_profile/MembraneTanh.hpp
+++ b/src/green/dielectric_profile/MembraneTanh.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef MEMBRANETANH_HPP
-#define MEMBRANETANH_HPP
+#pragma once
 
 #include <iosfwd>
 
@@ -101,5 +100,3 @@ public:
 };
 } // namespace dielectric_profile
 } // namespace pcm
-
-#endif // MEMBRANETANH_HPP

--- a/src/green/dielectric_profile/Metal.hpp
+++ b/src/green/dielectric_profile/Metal.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef METAL_HPP
-#define METAL_HPP
+#pragma once
 
 #include <complex>
 #include <iosfwd>
@@ -50,5 +49,3 @@ struct Metal __final {
 };
 } // namespace dielectric_profile
 } // namespace pcm
-
-#endif // METAL_HPP

--- a/src/green/dielectric_profile/OneLayerErf.hpp
+++ b/src/green/dielectric_profile/OneLayerErf.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef ONELAYERERF_HPP
-#define ONELAYERERF_HPP
+#pragma once
 
 #include <cmath>
 #include <iosfwd>
@@ -99,5 +98,3 @@ public:
 };
 } // namespace dielectric_profile
 } // namespace pcm
-
-#endif // ONELAYERERF_HPP

--- a/src/green/dielectric_profile/OneLayerTanh.hpp
+++ b/src/green/dielectric_profile/OneLayerTanh.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef ONELAYERTANH_HPP
-#define ONELAYERTANH_HPP
+#pragma once
 
 #include <iosfwd>
 
@@ -95,5 +94,3 @@ public:
 };
 } // namespace dielectric_profile
 } // namespace pcm
-
-#endif // ONELAYERTANH_HPP

--- a/src/green/dielectric_profile/ProfileTypes.hpp
+++ b/src/green/dielectric_profile/ProfileTypes.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef PROFILETYPES_HPP
-#define PROFILETYPES_HPP
+#pragma once
 
 #include "Config.hpp"
 
@@ -31,10 +30,10 @@
 #include <boost/variant.hpp>
 
 #include "Anisotropic.hpp"
-#include "OneLayerErf.hpp"
-#include "OneLayerTanh.hpp"
 #include "MembraneTanh.hpp"
 #include "Metal.hpp"
+#include "OneLayerErf.hpp"
+#include "OneLayerTanh.hpp"
 #include "Sharp.hpp"
 #include "Uniform.hpp"
 #include "Yukawa.hpp"
@@ -49,7 +48,8 @@ typedef boost::mpl::vector<Uniform,
                            OneLayerErf,
                            MembraneTanh,
                            Metal,
-                           Sharp> profile_types;
+                           Sharp>
+    profile_types;
 
 /*! One-layer diffuse profile types */
 typedef boost::mpl::vector<OneLayerTanh, OneLayerErf> onelayer_diffuse_profile_types;
@@ -96,5 +96,3 @@ inline double epsilon(const Permittivity & arg) {
 }
 } // namespace dielectric_profile
 } // namespace pcm
-
-#endif // PROFILETYPES_HPP

--- a/src/green/dielectric_profile/Sharp.hpp
+++ b/src/green/dielectric_profile/Sharp.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef SHARP_HPP
-#define SHARP_HPP
+#pragma once
 
 #include <iosfwd>
 
@@ -53,5 +52,3 @@ struct Sharp __final {
 };
 } // namespace dielectric_profile
 } // namespace pcm
-
-#endif // SHARP_HPP

--- a/src/green/dielectric_profile/Uniform.hpp
+++ b/src/green/dielectric_profile/Uniform.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef UNIFORM_HPP
-#define UNIFORM_HPP
+#pragma once
 
 #include <iostream>
 
@@ -48,5 +47,3 @@ struct Uniform __final {
 };
 } // namespace dielectric_profile
 } // namespace pcm
-
-#endif // UNIFORM_HPP

--- a/src/green/dielectric_profile/Yukawa.hpp
+++ b/src/green/dielectric_profile/Yukawa.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef YUKAWA_HPP
-#define YUKAWA_HPP
+#pragma once
 
 #include <iostream>
 
@@ -50,5 +49,3 @@ struct Yukawa __final {
 };
 } // namespace dielectric_profile
 } // namespace pcm
-
-#endif // YUKAWA_HPP

--- a/src/interface/Input.hpp
+++ b/src/interface/Input.hpp
@@ -21,11 +21,10 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef INPUT_HPP
-#define INPUT_HPP
+#pragma once
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "Config.hpp"
 
@@ -296,5 +295,3 @@ std::string trim(const char * src);
 std::string trim_and_upper(const char * src);
 } // namespace detail
 } // namespace pcm
-
-#endif // INPUT_HPP

--- a/src/interface/Meddle.hpp
+++ b/src/interface/Meddle.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef MEDDLE_HPP
-#define MEDDLE_HPP
+#pragma once
 
 #include "pcmsolver.h"
 
@@ -275,5 +274,3 @@ private:
   void mediumInfo(IGreensFunction * gf_i, IGreensFunction * gf_o) const;
 };
 } // namespace pcm
-
-#endif /* MEDDLE_HPP */

--- a/src/solver/CPCMSolver.hpp
+++ b/src/solver/CPCMSolver.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef CPCMSOLVER_HPP
-#define CPCMSOLVER_HPP
+#pragma once
 
 #include <iosfwd>
 #include <string>
@@ -103,5 +102,3 @@ private:
 ISolver * createCPCMSolver(const SolverData & data);
 } // namespace solver
 } // namespace pcm
-
-#endif // CPCMSOLVER_HPP

--- a/src/solver/IEFSolver.hpp
+++ b/src/solver/IEFSolver.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef IEFSOLVER_HPP
-#define IEFSOLVER_HPP
+#pragma once
 
 #include <iosfwd>
 #include <string>
@@ -128,5 +127,3 @@ private:
 ISolver * createIEFSolver(const SolverData & data);
 } // namespace solver
 } // namespace pcm
-
-#endif // IEFSOLVER_HPP

--- a/src/solver/ISolver.hpp
+++ b/src/solver/ISolver.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef ISOLVER_HPP
-#define ISOLVER_HPP
+#pragma once
 
 #include <iosfwd>
 
@@ -101,5 +100,3 @@ protected:
   virtual std::ostream & printSolver(std::ostream & os) = 0;
 };
 } // namespace pcm
-
-#endif // ISOLVER_HPP

--- a/src/solver/Solver.hpp
+++ b/src/solver/Solver.hpp
@@ -21,14 +21,13 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef SOLVER_HPP
-#define SOLVER_HPP
+#pragma once
 
 #include "Config.hpp"
 
-#include "ISolver.hpp"
-#include "IEFSolver.hpp"
 #include "CPCMSolver.hpp"
+#include "IEFSolver.hpp"
+#include "ISolver.hpp"
 #include "utils/Factory.hpp"
 
 /*!
@@ -57,5 +56,3 @@ inline Factory<detail::CreateSolver> bootstrapFactory() {
 }
 } // namespace solver
 } // namespace pcm
-
-#endif // SOLVER_HPP

--- a/src/solver/SolverData.hpp
+++ b/src/solver/SolverData.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef SOLVERDATA_HPP
-#define SOLVERDATA_HPP
+#pragma once
 
 #include "Config.hpp"
 
@@ -48,5 +47,3 @@ struct SolverData {
   }
 };
 } // namespace pcm
-
-#endif // SOLVERDATA_HPP

--- a/src/solver/SolverImpl.hpp
+++ b/src/solver/SolverImpl.hpp
@@ -21,6 +21,8 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
+#pragma once
+
 #include <cmath>
 
 #include "Config.hpp"

--- a/src/utils/Atom.hpp
+++ b/src/utils/Atom.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef ATOM_HPP
-#define ATOM_HPP
+#pragma once
 
 #include <iosfwd>
 #include <string>
@@ -136,5 +135,3 @@ Factory<detail::CreateRadiiSet> bootstrapRadiiSet();
 /*! An atom is invalid if it has zero radius */
 bool invalid(const utils::Atom & atom);
 } // namespace pcm
-
-#endif // ATOM_HPP

--- a/src/utils/ChargeDistribution.hpp
+++ b/src/utils/ChargeDistribution.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef CHARGEDISTRIBUTION_HPP
-#define CHARGEDISTRIBUTION_HPP
+#pragma once
 
 #include <iosfwd>
 
@@ -65,7 +64,8 @@ typedef pcm::function<double(const Eigen::Vector3d &, const Eigen::Vector3d &)>
  */
 typedef pcm::function<double(const Eigen::Vector3d &,
                              const Eigen::Vector3d &,
-                             const Eigen::Vector3d &)> GFDerivative;
+                             const Eigen::Vector3d &)>
+    GFDerivative;
 
 /*! \brief Computes Newton potential in a set of points for given Green's function
  * and classical charge distribution
@@ -105,5 +105,3 @@ Eigen::VectorXd computeDipolarPotential(const GFDerivative & gf,
 ChargeDistribution nuclearChargeDistribution(const Molecule & mol);
 } // namespace utils
 } // namespace pcm
-
-#endif // CHARGEDISTRIBUTION_HPP

--- a/src/utils/Factory.hpp
+++ b/src/utils/Factory.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef FACTORY_HPP
-#define FACTORY_HPP
+#pragma once
 
 #include <map>
 #include <string>
@@ -177,5 +176,3 @@ public:
 };
 #endif /* HAS_CXX11_VARIADIC_TEMPLATES */
 } // namespace pcm
-
-#endif // FACTORY_HPP

--- a/src/utils/ForId.hpp
+++ b/src/utils/ForId.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef FORID_HPP
-#define FORID_HPP
+#pragma once
 
 #include <stdexcept>
 #include <string>
@@ -435,7 +434,7 @@ template <typename T1, typename T2, typename T3> struct ApplyFunctor<3, T1, T2, 
    */
   template <typename ReturnType, typename T, typename InputType>
   static ReturnType * apply(T & f, const InputType & data) {
-    return (f.template operator() < T1, T2, T3 > (data));
+    return (f.template operator()<T1, T2, T3>(data));
   }
 };
 
@@ -452,7 +451,7 @@ template <typename T1, typename T2, typename T3> struct ApplyFunctor<2, T1, T2, 
    */
   template <typename ReturnType, typename T, typename InputType>
   static ReturnType * apply(T & f, const InputType & data) {
-    return (f.template operator() < T1, T2 > (data));
+    return (f.template operator()<T1, T2>(data));
   }
 };
 
@@ -469,7 +468,7 @@ template <typename T1, typename T2, typename T3> struct ApplyFunctor<1, T1, T2, 
    */
   template <typename ReturnType, typename T, typename InputType>
   static ReturnType * apply(T & f, const InputType & data) {
-    return (f.template operator() < T1 > (data));
+    return (f.template operator()<T1>(data));
   }
 };
 /**@}*/
@@ -533,5 +532,3 @@ ReturnType * for_id(T & f, const InputType & data, int id1) {
   return for_id_impl<1, S1>::template execute<ReturnType>(f, data, id1);
 }
 /**@}*/
-
-#endif // FORIDTDSOLVER_HPP

--- a/src/utils/FortranCUtils.hpp
+++ b/src/utils/FortranCUtils.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef FORTRANCUTILS_HPP
-#define FORTRANCUTILS_HPP
+#pragma once
 
 #include "FCMangle.hpp"
 
@@ -56,5 +55,3 @@ void pcmsolver_f2c_string(char * src, char * dest, int * len);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // FORTRANCUTILS_HPP

--- a/src/utils/Interpolation.hpp
+++ b/src/utils/Interpolation.hpp
@@ -1,30 +1,33 @@
-#ifndef INTERPOLATION_NEW_HPP
-#define INTERPOLATION_NEW_HPP
+#pragma once
 /**
  * @file Interpolation.hpp
- * 
+ *
  * @brief class for calculating the surface interpolation
  */
-#include "Vector3.hpp"
 #include "Vector2.hpp"
+#include "Vector3.hpp"
 #include <stdlib.h>
 #ifdef DEBUG2
-  #include <cstdio>
+#include <cstdio>
 #endif
-class Interpolation{
-  public:	
+class Interpolation {
+public:
+  Vector3 **** pSurfaceInterpolation; ///< surface interpolation polinomials
 
-  Vector3 ****pSurfaceInterpolation; ///< surface interpolation polinomials
+  unsigned int
+      grade; ///< the grade aka number of neighbours that constitute one polinomial
+  unsigned int noPatch; ///< number of patches
+  unsigned int nLevels; ///< number of refinements
+  unsigned int n;       ///< number of polinomials
 
-  unsigned int grade;          ///< the grade aka number of neighbours that constitute one polinomial
-  unsigned int noPatch;        ///< number of patches
-  unsigned int nLevels;        ///< number of refinements
-  unsigned int n;              ///< number of polinomials
+  double h; ///< 1/step_size on reference domain
+  Vector3 * coeff;
 
-  double h;                          ///< 1/step_size on reference domain
-  Vector3 *coeff;
-
-  Interpolation() { grade = 0; nLevels = 0; h = 0;};
+  Interpolation() {
+    grade = 0;
+    nLevels = 0;
+    h = 0;
+  };
 
   /**
    * @brief computes the coefficients of the interpolation polynomial
@@ -37,7 +40,11 @@ class Interpolation{
    * @param[in] nLevelsIn number of refinements
    * @param[in] noPatchIn number of patches used
    */
-  Interpolation(Vector3*** U, int gradeIn, const int type, unsigned int nLevelsIn, unsigned int noPatchIn);
+  Interpolation(Vector3 *** U,
+                int gradeIn,
+                const int type,
+                unsigned int nLevelsIn,
+                unsigned int noPatchIn);
 
   /**
    * @brief computes the interpolation in the 2 point vector
@@ -46,7 +53,7 @@ class Interpolation{
    * @param[in] patch the patch to which the point belongs
    */
   Vector3 Chi(Vector2 a, int patch);
-  
+
   /**
    * @brief computes the derivative of the interpolation in the 2 point vector
    *
@@ -54,7 +61,7 @@ class Interpolation{
    * @param[in] patch the patch to which the point belongs
    */
   Vector3 dChi_dx(Vector2 a, int patch);
-  
+
   /**
    * @brief computes the derivative of the interpolation in the 2 point vector
    *
@@ -62,7 +69,7 @@ class Interpolation{
    * @param[in] patch the patch to which the point belongs
    */
   Vector3 dChi_dy(Vector2 a, int patch);
-  
+
   Vector3 d2Chi_dy2(Vector2 a, int patch);
   Vector3 d2Chi_dx2(Vector2 a, int patch);
   Vector3 d2Chi_dxy(Vector2 a, int patch);
@@ -80,5 +87,3 @@ class Interpolation{
    */
   ~Interpolation();
 };
-#endif
-

--- a/src/utils/Logger.hpp
+++ b/src/utils/Logger.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef LOGGER_HPP
-#define LOGGER_HPP
+#pragma once
 
 #include <ctime>
 #include <mutex>
@@ -76,8 +75,8 @@ public:
     }
     policy_->open_ostream(name);
     // Write the logfile header
-    logStream_ << "\t\tPCMSolver execution log\n" << buildInfo()
-               << "\n\t\tLog started : " << getTime() << std::endl;
+    logStream_ << "\t\tPCMSolver execution log\n"
+               << buildInfo() << "\n\t\tLog started : " << getTime() << std::endl;
   }
   /// Destructor
   ~logger() {
@@ -112,5 +111,3 @@ inline std::string getTime() {
 }
 
 } // close namespace logging
-
-#endif // LOGGER_HPP

--- a/src/utils/LoggerImpl.hpp
+++ b/src/utils/LoggerImpl.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef LOGGERIMPL_HPP
-#define LOGGERIMPL_HPP
+#pragma once
 
 #include <fstream>
 #include <memory>
@@ -88,5 +87,3 @@ public:
 };
 
 } // close namespace logging
-
-#endif // LOGGERIMPL_HPP

--- a/src/utils/MathUtils.hpp
+++ b/src/utils/MathUtils.hpp
@@ -21,15 +21,14 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef MATHUTILS_HPP
-#define MATHUTILS_HPP
+#pragma once
 
 #include <algorithm>
 #include <bitset>
 #include <cmath>
 #include <fstream>
-#include <iterator>
 #include <iomanip>
+#include <iterator>
 #include <limits>
 #include <vector>
 
@@ -38,9 +37,9 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include "cnpy.hpp"
 #include "SplineFunction.hpp"
 #include "Symmetry.hpp"
+#include "cnpy.hpp"
 
 namespace pcm {
 namespace utils {
@@ -415,5 +414,3 @@ inline Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> npy_load(
 } // namespace custom
 /*! @} */
 } // namespace cnpy
-
-#endif // MATHUTILS_HPP

--- a/src/utils/Molecule.hpp
+++ b/src/utils/Molecule.hpp
@@ -21,12 +21,11 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef MOLECULE_HPP
-#define MOLECULE_HPP
+#pragma once
 
 #include <iosfwd>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "Config.hpp"
 
@@ -248,5 +247,3 @@ Eigen::VectorXd computeMEP(const std::vector<cavity::Element> & el,
  *  \return MEP at finite elements center
  */
 } // namespace pcm
-
-#endif // MOLECULE_HPP

--- a/src/utils/QuadratureRules.hpp
+++ b/src/utils/QuadratureRules.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef QUADRATURERULES_HPP
-#define QUADRATURERULES_HPP
+#pragma once
 
 #include <vector>
 
@@ -209,6 +208,5 @@ namespace mpl = boost::mpl;
 
 typedef mpl::map<mpl::pair<mpl::int_<16>, gauss16>,
                  mpl::pair<mpl::int_<32>, gauss32>,
-                 mpl::pair<mpl::int_<64>, gauss64> > rules_map;
-
-#endif // QUADRATURERULES_HPP
+                 mpl::pair<mpl::int_<64>, gauss64> >
+    rules_map;

--- a/src/utils/Solvent.hpp
+++ b/src/utils/Solvent.hpp
@@ -21,12 +21,11 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef SOLVENT_HPP
-#define SOLVENT_HPP
+#pragma once
 
 #include <iosfwd>
-#include <string>
 #include <map>
+#include <string>
 
 #include "Config.hpp"
 
@@ -70,5 +69,3 @@ typedef std::map<std::string, utils::Solvent> SolventMap;
  */
 SolventMap & solvents();
 } // namespace pcm
-
-#endif // SOLVENT_HPP

--- a/src/utils/Sphere.hpp
+++ b/src/utils/Sphere.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef SPHERE_HPP
-#define SPHERE_HPP
+#pragma once
 
 #include <iosfwd>
 #include <string>
@@ -77,5 +76,3 @@ void transfer_spheres(const std::vector<utils::Sphere> & spheres,
                       Eigen::Matrix3Xd & sphereCenter,
                       Eigen::VectorXd & sphereRadius);
 } // namespace pcm
-
-#endif // SPHERE_HPP

--- a/src/utils/SplineFunction.hpp
+++ b/src/utils/SplineFunction.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef SPLINEFUNCTION_HPP
-#define SPLINEFUNCTION_HPP
+#pragma once
 
 #include <algorithm>
 
@@ -95,4 +94,3 @@ private:
   }
 #endif /*HAS_CXX11_LAMBDA */
 };
-#endif // SPLINEFUNCTION_HPP

--- a/src/utils/Stencils.hpp
+++ b/src/utils/Stencils.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef STENCILS_HPP
-#define STENCILS_HPP
+#pragma once
 
 #include <functional>
 
@@ -132,5 +131,3 @@ inline double sevenPointStencil(const DifferentiableFunction & func,
 
   return (function_values.dot(stencil) / step);
 }
-
-#endif // STENCILS_HPP

--- a/src/utils/Symmetry.hpp
+++ b/src/utils/Symmetry.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef SYMMETRY_HPP
-#define SYMMETRY_HPP
+#pragma once
 
 #include <algorithm>
 #include <cmath>
@@ -81,5 +80,3 @@ public:
  * \note C1 is built as Symmetry C1 = buildGroup(0, 0, 0, 0);
  */
 Symmetry buildGroup(int _nr_gen, int _gen1, int _gen2, int _gen3);
-
-#endif // SYMMETRY_HPP

--- a/src/utils/Timer.hpp
+++ b/src/utils/Timer.hpp
@@ -21,8 +21,7 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#ifndef TIMER_HPP
-#define TIMER_HPP
+#pragma once
 
 #include <fstream>
 #include <string>
@@ -158,8 +157,8 @@ inline double get_cpu_time() {
   }
 }
 #else /* _WIN32 */
-#include <time.h>
 #include <sys/time.h>
+#include <time.h>
 
 inline double get_wall_time() {
   struct timeval time;
@@ -173,5 +172,3 @@ inline double get_wall_time() {
 inline double get_cpu_time() { return (double)clock() / CLOCKS_PER_SEC; }
 #endif /* _WIN32 */
 } // namespace timer
-
-#endif // TIMER_HPP

--- a/src/utils/Vector2.hpp
+++ b/src/utils/Vector2.hpp
@@ -4,48 +4,33 @@
  * @brief 2d vector class
  */
 
-#ifndef VECTOR2_HPP
-#define VECTOR2_HPP
+#pragma once
 
 #include <math.h>
 
 /// type definition
-class Vector2
-{
+class Vector2 {
 public:
-    double x, y;
+  double x, y;
 
-    Vector2(double xi = 0.0, double yi = 0.0):x(xi),y(yi) {}
-
+  Vector2(double xi = 0.0, double yi = 0.0) : x(xi), y(yi) {}
 };
 
 // vector addition
-inline Vector2 vector2Add(Vector2 a, Vector2 b)
-{
-    return Vector2 (a.x+b.x, a.y+b.y);
+inline Vector2 vector2Add(Vector2 a, Vector2 b) {
+  return Vector2(a.x + b.x, a.y + b.y);
 }
 
 // vector subtration
-inline Vector2 vector2Sub(Vector2 a, Vector2 b)
-{
-    return Vector2(a.x-b.x, a.y-b.y);
+inline Vector2 vector2Sub(Vector2 a, Vector2 b) {
+  return Vector2(a.x - b.x, a.y - b.y);
 }
 
 // multiplication by scalar
-inline Vector2 vector2SMul(double a,Vector2 b)
-{
-    return Vector2 (a*b.x, a*b.y);
-}
+inline Vector2 vector2SMul(double a, Vector2 b) { return Vector2(a * b.x, a * b.y); }
 
 // scalar product
-inline double vector2Dot(Vector2 a,Vector2 b)
-{
-    return(a.x*b.x + a.y*b.y);
-}
+inline double vector2Dot(Vector2 a, Vector2 b) { return (a.x * b.x + a.y * b.y); }
 
 // euclidean norm
-inline double vector2Norm(Vector2 a)
-{
-    return(sqrt(a.x*a.x + a.y*a.y));
-}
-#endif
+inline double vector2Norm(Vector2 a) { return (sqrt(a.x * a.x + a.y * a.y)); }

--- a/src/utils/Vector3.hpp
+++ b/src/utils/Vector3.hpp
@@ -3,59 +3,50 @@
  *
  * @brief 3d vector class
  */
-#ifndef VECTOR3_HPP
-#define VECTOR3_HPP
+#pragma once
 
 #include <math.h>
 
-class Vector3
-{
+class Vector3 {
 public:
-    double x, y, z;
+  double x, y, z;
 
-    Vector3 (double xi = 0.0, double yi = 0.0, double zi = 0.0) : x(xi), y(yi), z(zi) {}
+  Vector3(double xi = 0.0, double yi = 0.0, double zi = 0.0) : x(xi), y(yi), z(zi) {}
 };
 // vector addition
-inline Vector3 vector3Add(Vector3 a,Vector3 b)
-{
-    return Vector3(a.x+b.x, a.y+b.y, a.z+b.z);
+inline Vector3 vector3Add(Vector3 a, Vector3 b) {
+  return Vector3(a.x + b.x, a.y + b.y, a.z + b.z);
 }
 
 // vector in-place addition
-inline void vector3AddTo(Vector3* a,Vector3 b)
-{
-    a->x += b.x;
-    a->y += b.y;
-    a->z += b.z;
+inline void vector3AddTo(Vector3 * a, Vector3 b) {
+  a->x += b.x;
+  a->y += b.y;
+  a->z += b.z;
 }
 
 // vector subtration
-inline Vector3 vector3Sub(Vector3 a,Vector3 b)
-{
-    return Vector3(a.x-b.x, a.y-b.y, a.z-b.z);
+inline Vector3 vector3Sub(Vector3 a, Vector3 b) {
+  return Vector3(a.x - b.x, a.y - b.y, a.z - b.z);
 }
 
 // cross product
-inline Vector3 vector3Mul(Vector3 a,Vector3 b)
-{
-    return Vector3 (a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x);
+inline Vector3 vector3Mul(Vector3 a, Vector3 b) {
+  return Vector3(
+      a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x);
 }
 
 // multiplication by scalar
-inline Vector3 vector3SMul(double a,Vector3 b)
-{
-    return Vector3(a*b.x, a*b.y, a*b.z);
+inline Vector3 vector3SMul(double a, Vector3 b) {
+  return Vector3(a * b.x, a * b.y, a * b.z);
 }
 
 // scalar product
-inline double vector3Dot(Vector3 a,Vector3 b)
-{
-    return(a.x*b.x + a.y*b.y + a.z*b.z);
+inline double vector3Dot(Vector3 a, Vector3 b) {
+  return (a.x * b.x + a.y * b.y + a.z * b.z);
 }
 
 // euclidean norm
-inline double vector3Norm(Vector3 a)
-{
-    return(sqrt(a.x*a.x + a.y*a.y + a.z*a.z));
+inline double vector3Norm(Vector3 a) {
+  return (sqrt(a.x * a.x + a.y * a.y + a.z * a.z));
 }
-#endif

--- a/src/utils/cnpy.hpp
+++ b/src/utils/cnpy.hpp
@@ -1,267 +1,291 @@
-//Copyright (C) 2011  Carl Rogers
-//Released under MIT License
-//license available in LICENSE file, or at http://www.opensource.org/licenses/mit-license.php
+// Copyright (C) 2011  Carl Rogers
+// Released under MIT License
+// license available in LICENSE file, or at
+// http://www.opensource.org/licenses/mit-license.php
 
-#ifndef LIBCNPY_H_
-#define LIBCNPY_H_
+#pragma once
 
-#include <iostream>
 #include <cassert>
 #include <cstdio>
+#include <iostream>
 #include <map>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <typeinfo>
 #include <vector>
 #include <zlib.h>
 
-namespace cnpy
-{
-    struct NpyArray
-    {
-        char* data;
-        std::vector<unsigned int> shape;
-        unsigned int word_size;
-        bool fortran_order;
-        void destruct() {
-            delete[] data;
-        }
-    };
+namespace cnpy {
+struct NpyArray {
+  char * data;
+  std::vector<unsigned int> shape;
+  unsigned int word_size;
+  bool fortran_order;
+  void destruct() { delete[] data; }
+};
 
-    struct npz_t : public std::map<std::string, NpyArray>
-    {
-        void destruct() {
-            npz_t::iterator it = this->begin();
-            for(; it != this->end(); ++it) (*it).second.destruct();
-        }
-    };
+struct npz_t : public std::map<std::string, NpyArray> {
+  void destruct() {
+    npz_t::iterator it = this->begin();
+    for (; it != this->end(); ++it)
+      (*it).second.destruct();
+  }
+};
 
-    char BigEndianTest();
-    char map_type(const std::type_info& t);
-    template <typename T>
-    std::vector<char> create_npy_header(const T* data, const unsigned int* shape, const unsigned int ndims, bool fortran_order = false);
-    void parse_npy_header(FILE* fp,unsigned int& word_size, unsigned int*& shape,
-                          unsigned int& ndims, bool& fortran_order);
-    void parse_zip_footer(FILE* fp, unsigned short& nrecs,
-                          unsigned int& global_header_size, unsigned int& global_header_offset);
-    npz_t npz_load(std::string fname);
-    NpyArray npz_load(std::string fname, std::string varname);
-    NpyArray npy_load(std::string fname);
+char BigEndianTest();
+char map_type(const std::type_info & t);
+template <typename T>
+std::vector<char> create_npy_header(const T * data,
+                                    const unsigned int * shape,
+                                    const unsigned int ndims,
+                                    bool fortran_order = false);
+void parse_npy_header(FILE * fp,
+                      unsigned int & word_size,
+                      unsigned int *& shape,
+                      unsigned int & ndims,
+                      bool & fortran_order);
+void parse_zip_footer(FILE * fp,
+                      unsigned short & nrecs,
+                      unsigned int & global_header_size,
+                      unsigned int & global_header_offset);
+npz_t npz_load(std::string fname);
+NpyArray npz_load(std::string fname, std::string varname);
+NpyArray npy_load(std::string fname);
 
-    template <typename T>
-    std::vector<char> & operator+=(std::vector<char> & lhs, const T rhs)
-    {
-        //write in little endian
-        for(size_t byte = 0; byte < sizeof(T); byte++) {
-            char val = *((char*)&rhs+byte);
-            lhs.push_back(val);
-        }
-        return lhs;
+template <typename T>
+std::vector<char> & operator+=(std::vector<char> & lhs, const T rhs) {
+  // write in little endian
+  for (size_t byte = 0; byte < sizeof(T); byte++) {
+    char val = *((char *)&rhs + byte);
+    lhs.push_back(val);
+  }
+  return lhs;
+}
+
+template <>
+std::vector<char> & operator+=(std::vector<char> & lhs, const std::string rhs);
+template <>
+std::vector<char> & operator+=(std::vector<char> & lhs, const char * rhs);
+
+template <typename T>
+std::string tostring(T i, int /* pad */ = 0, char /* padval */ = ' ') {
+  std::stringstream s;
+  s << i;
+  return s.str();
+}
+
+template <typename T>
+void npy_save(std::string fname,
+              const T * data,
+              const unsigned int * shape,
+              const unsigned int ndims,
+              std::string mode = "w",
+              bool fortran_order = false) {
+  FILE * fp = NULL;
+
+  if (mode == "a")
+    fp = fopen(fname.c_str(), "r+b");
+
+  if (fp) {
+    // file exists. we need to append to it. read the header, modify the array size
+    unsigned int word_size, tmp_dims;
+    unsigned int * tmp_shape = 0;
+    // bool fortran_order;
+    parse_npy_header(fp, word_size, tmp_shape, tmp_dims, fortran_order);
+    assert(!fortran_order);
+
+    if (word_size != sizeof(T)) {
+      std::cout << "libnpy error: " << fname << " has word size " << word_size
+                << " but npy_save appending data sized " << sizeof(T) << "\n";
+      assert(word_size == sizeof(T));
+    }
+    if (tmp_dims != ndims) {
+      std::cout
+          << "libnpy error: npy_save attempting to append misdimensioned data to "
+          << fname << "\n";
+      assert(tmp_dims == ndims);
     }
 
-    template <>
-    std::vector<char> & operator+=(std::vector<char> & lhs, const std::string rhs);
-    template <>
-    std::vector<char> & operator+=(std::vector<char> & lhs, const char * rhs);
-
-    template <typename T>
-    std::string tostring(T i, int /* pad */ = 0, char /* padval */ = ' ')
-    {
-        std::stringstream s;
-        s << i;
-        return s.str();
+    for (size_t i = 1; i < ndims; i++) {
+      if (shape[i] != tmp_shape[i]) {
+        std::cout << "libnpy error: npy_save attempting to append misshaped data to "
+                  << fname << "\n";
+        assert(shape[i] == tmp_shape[i]);
+      }
     }
+    tmp_shape[0] += shape[0];
 
-    template <typename T>
-    void npy_save(std::string fname, const T* data, const unsigned int* shape, const unsigned int ndims,
-                  std::string mode = "w", bool fortran_order = false)
-    {
-        FILE* fp = NULL;
+    fseek(fp, 0, SEEK_SET);
+    std::vector<char> header =
+        create_npy_header(data, tmp_shape, ndims, fortran_order);
+    fwrite(&header[0], sizeof(char), header.size(), fp);
+    fseek(fp, 0, SEEK_END);
 
-        if (mode == "a") fp = fopen(fname.c_str(), "r+b");
+    delete[] tmp_shape;
+  } else {
+    fp = fopen(fname.c_str(), "wb");
+    std::vector<char> header = create_npy_header(data, shape, ndims, fortran_order);
+    fwrite(&header[0], sizeof(char), header.size(), fp);
+  }
 
-        if (fp) {
-            //file exists. we need to append to it. read the header, modify the array size
-            unsigned int word_size, tmp_dims;
-            unsigned int * tmp_shape = 0;
-            //bool fortran_order;
-            parse_npy_header(fp,word_size,tmp_shape,tmp_dims,fortran_order);
-            assert(!fortran_order);
+  unsigned int nels = 1;
+  for (size_t i = 0; i < ndims; ++i)
+    nels *= shape[i];
 
-            if (word_size != sizeof(T)) {
-                std::cout << "libnpy error: " << fname << " has word size " << word_size <<
-                          " but npy_save appending data sized " << sizeof(T) << "\n";
-                assert( word_size == sizeof(T) );
-            }
-            if (tmp_dims != ndims) {
-                std::cout << "libnpy error: npy_save attempting to append misdimensioned data to " <<
-                          fname << "\n";
-                assert(tmp_dims == ndims);
-            }
+  fwrite(data, sizeof(T), nels, fp);
+  fclose(fp);
+}
 
-            for (size_t i = 1; i < ndims; i++) {
-                if (shape[i] != tmp_shape[i]) {
-                    std::cout <<"libnpy error: npy_save attempting to append misshaped data to " << fname
-                              << "\n";
-                    assert(shape[i] == tmp_shape[i]);
-                }
-            }
-            tmp_shape[0] += shape[0];
+template <typename T>
+void npz_save(std::string zipname,
+              std::string fname,
+              const T * data,
+              const unsigned int * shape,
+              const unsigned int ndims,
+              std::string mode = "w",
+              bool fortran_order = false) {
+  // first, append a .npy to the fname
+  fname += ".npy";
 
-            fseek(fp, 0, SEEK_SET);
-            std::vector<char> header = create_npy_header(data, tmp_shape, ndims, fortran_order);
-            fwrite(&header[0], sizeof(char), header.size(), fp);
-            fseek(fp, 0, SEEK_END);
+  // now, on with the show
+  FILE * fp = NULL;
+  unsigned short nrecs = 0;
+  unsigned int global_header_offset = 0;
+  std::vector<char> global_header;
 
-            delete[] tmp_shape;
-        } else {
-            fp = fopen(fname.c_str(), "wb");
-            std::vector<char> header = create_npy_header(data, shape, ndims, fortran_order);
-            fwrite(&header[0], sizeof(char), header.size(), fp);
-        }
+  if (mode == "a")
+    fp = fopen(zipname.c_str(), "r+b");
 
-        unsigned int nels = 1;
-        for (size_t i = 0; i < ndims; ++i) nels *= shape[i];
-
-        fwrite(data, sizeof(T), nels, fp);
-        fclose(fp);
+  if (fp) {
+    // zip file exists. we need to add a new npy file to it.
+    // first read the footer. this gives us the offset and size of the global header
+    // then read and store the global header.
+    // below, we will write the the new data at the start of the global header then
+    // append the global header and footer below it
+    unsigned int global_header_size;
+    parse_zip_footer(fp, nrecs, global_header_size, global_header_offset);
+    fseek(fp, global_header_offset, SEEK_SET);
+    global_header.resize(global_header_size);
+    size_t res = fread(&global_header[0], sizeof(char), global_header_size, fp);
+    if (res != global_header_size) {
+      throw std::runtime_error(
+          "npz_save: header read error while adding to existing zip");
     }
+    fseek(fp, global_header_offset, SEEK_SET);
+  } else {
+    fp = fopen(zipname.c_str(), "wb");
+  }
 
-    template <typename T>
-    void npz_save(std::string zipname, std::string fname, const T* data, const unsigned int* shape, const unsigned int ndims,
-                  std::string mode = "w", bool fortran_order = false)
-    {
-        //first, append a .npy to the fname
-        fname += ".npy";
+  std::vector<char> npy_header =
+      create_npy_header(data, shape, ndims, fortran_order);
 
-        //now, on with the show
-        FILE * fp = NULL;
-        unsigned short nrecs = 0;
-        unsigned int global_header_offset = 0;
-        std::vector<char> global_header;
+  unsigned long nels = 1;
+  for (size_t m = 0; m < ndims; ++m)
+    nels *= shape[m];
+  int nbytes = nels * sizeof(T) + npy_header.size();
 
-        if(mode == "a") fp = fopen(zipname.c_str(), "r+b");
+  // get the CRC of the data to be added
+  unsigned int crc = crc32(0L, (unsigned char *)&npy_header[0], npy_header.size());
+  crc = crc32(crc, (unsigned char *)data, nels * sizeof(T));
 
-        if (fp) {
-            //zip file exists. we need to add a new npy file to it.
-            //first read the footer. this gives us the offset and size of the global header
-            //then read and store the global header.
-            //below, we will write the the new data at the start of the global header then append the global header and footer below it
-            unsigned int global_header_size;
-            parse_zip_footer(fp, nrecs, global_header_size, global_header_offset);
-            fseek(fp, global_header_offset, SEEK_SET);
-            global_header.resize(global_header_size);
-            size_t res = fread(&global_header[0], sizeof(char), global_header_size, fp);
-            if (res != global_header_size) {
-                throw std::runtime_error("npz_save: header read error while adding to existing zip");
-            }
-            fseek(fp, global_header_offset, SEEK_SET);
-        } else {
-            fp = fopen(zipname.c_str(), "wb");
-        }
+  // build the local header
+  std::vector<char> local_header;
+  local_header += "PK";                         // first part of sig
+  local_header += (unsigned short)0x0403;       // second part of sig
+  local_header += (unsigned short)20;           // min version to extract
+  local_header += (unsigned short)0;            // general purpose bit flag
+  local_header += (unsigned short)0;            // compression method
+  local_header += (unsigned short)0;            // file last mod time
+  local_header += (unsigned short)0;            // file last mod date
+  local_header += (unsigned int)crc;            // crc
+  local_header += (unsigned int)nbytes;         // compressed size
+  local_header += (unsigned int)nbytes;         // uncompressed size
+  local_header += (unsigned short)fname.size(); // fname length
+  local_header += (unsigned short)0;            // extra field length
+  local_header += fname;
 
-        std::vector<char> npy_header = create_npy_header(data, shape, ndims, fortran_order);
+  // build global header
+  global_header += "PK";                   // first part of sig
+  global_header += (unsigned short)0x0201; // second part of sig
+  global_header += (unsigned short)20;     // version made by
+  global_header.insert(
+      global_header.end(), local_header.begin() + 4, local_header.begin() + 30);
+  global_header += (unsigned short)0; // file comment length
+  global_header += (unsigned short)0; // disk number where file starts
+  global_header += (unsigned short)0; // internal file attributes
+  global_header += (unsigned int)0;   // external file attributes
+  global_header += (unsigned int)global_header_offset; // relative offset of local
+                                                       // file header, since it
+                                                       // begins where the global
+                                                       // header used to begin
+  global_header += fname;
 
-        unsigned long nels = 1;
-        for (size_t m = 0; m < ndims; ++m) nels *= shape[m];
-        int nbytes = nels*sizeof(T) + npy_header.size();
+  // build footer
+  std::vector<char> footer;
+  footer += "PK";                               // first part of sig
+  footer += (unsigned short)0x0605;             // second part of sig
+  footer += (unsigned short)0;                  // number of this disk
+  footer += (unsigned short)0;                  // disk where footer starts
+  footer += (unsigned short)(nrecs + 1);        // number of records on this disk
+  footer += (unsigned short)(nrecs + 1);        // total number of records
+  footer += (unsigned int)global_header.size(); // nbytes of global headers
+  footer += (unsigned int)(global_header_offset + nbytes +
+                           local_header.size()); // offset of start of global
+                                                 // headers, since global header now
+                                                 // starts after newly written array
+  footer += (unsigned short)0;                   // zip file comment length
 
-        //get the CRC of the data to be added
-        unsigned int crc = crc32(0L, (unsigned char*)&npy_header[0], npy_header.size());
-        crc = crc32(crc, (unsigned char*)data, nels*sizeof(T));
+  // write everything
+  fwrite(&local_header[0], sizeof(char), local_header.size(), fp);
+  fwrite(&npy_header[0], sizeof(char), npy_header.size(), fp);
+  fwrite(data, sizeof(T), nels, fp);
+  fwrite(&global_header[0], sizeof(char), global_header.size(), fp);
+  fwrite(&footer[0], sizeof(char), footer.size(), fp);
+  fclose(fp);
+}
 
-        //build the local header
-        std::vector<char> local_header;
-        local_header += "PK"; //first part of sig
-        local_header += (unsigned short) 0x0403; //second part of sig
-        local_header += (unsigned short) 20; //min version to extract
-        local_header += (unsigned short) 0; //general purpose bit flag
-        local_header += (unsigned short) 0; //compression method
-        local_header += (unsigned short) 0; //file last mod time
-        local_header += (unsigned short) 0;     //file last mod date
-        local_header += (unsigned int) crc; //crc
-        local_header += (unsigned int) nbytes; //compressed size
-        local_header += (unsigned int) nbytes; //uncompressed size
-        local_header += (unsigned short) fname.size(); //fname length
-        local_header += (unsigned short) 0; //extra field length
-        local_header += fname;
+template <typename T>
+std::vector<char> create_npy_header(const T * /* data */,
+                                    const unsigned int * shape,
+                                    const unsigned int ndims,
+                                    bool fortran_order) {
 
-        //build global header
-        global_header += "PK"; //first part of sig
-        global_header += (unsigned short) 0x0201; //second part of sig
-        global_header += (unsigned short) 20; //version made by
-        global_header.insert(global_header.end(), local_header.begin()+4,
-                             local_header.begin()+30);
-        global_header += (unsigned short) 0; //file comment length
-        global_header += (unsigned short) 0; //disk number where file starts
-        global_header += (unsigned short) 0; //internal file attributes
-        global_header += (unsigned int) 0; //external file attributes
-        global_header += (unsigned int)
-                         global_header_offset; //relative offset of local file header, since it begins where the global header used to begin
-        global_header += fname;
+  std::vector<char> dict;
+  dict += "{'descr': '";
+  dict += BigEndianTest();
+  dict += map_type(typeid(T));
+  dict += tostring(sizeof(T));
+  if (fortran_order) {
+    dict += "', 'fortran_order': True, 'shape': (";
+  } else {
+    dict += "', 'fortran_order': False, 'shape': (";
+  }
+  dict += tostring(shape[0]);
+  for (size_t i = 1; i < ndims; ++i) {
+    dict += ", ";
+    dict += tostring(shape[i]);
+  }
+  if (ndims == 1)
+    dict += ",";
+  dict += "), }";
+  // pad with spaces so that preamble+dict is modulo 16 bytes. preamble is 10 bytes.
+  // dict needs to end with \n
+  int remainder = 16 - (10 + dict.size()) % 16;
+  dict.insert(dict.end(), remainder, ' ');
+  dict.back() = '\n';
 
-        //build footer
-        std::vector<char> footer;
-        footer += "PK"; //first part of sig
-        footer += (unsigned short) 0x0605; //second part of sig
-        footer += (unsigned short) 0; //number of this disk
-        footer += (unsigned short) 0; //disk where footer starts
-        footer += (unsigned short) (nrecs+1); //number of records on this disk
-        footer += (unsigned short) (nrecs+1); //total number of records
-        footer += (unsigned int) global_header.size(); //nbytes of global headers
-        footer += (unsigned int) (global_header_offset + nbytes +
-                                  local_header.size()); //offset of start of global headers, since global header now starts after newly written array
-        footer += (unsigned short) 0; //zip file comment length
+  std::vector<char> header;
+  header += (char)0x93;
+  header += "NUMPY";
+  header += (char)0x01; // major version of numpy format
+  header += (char)0x00; // minor version of numpy format
+  header += (unsigned short)dict.size();
+  header.insert(header.end(), dict.begin(), dict.end());
 
-        //write everything
-        fwrite(&local_header[0], sizeof(char), local_header.size(), fp);
-        fwrite(&npy_header[0], sizeof(char), npy_header.size(), fp);
-        fwrite(data, sizeof(T), nels, fp);
-        fwrite(&global_header[0], sizeof(char), global_header.size(), fp);
-        fwrite(&footer[0], sizeof(char), footer.size(), fp);
-        fclose(fp);
-    }
-
-    template <typename T>
-    std::vector<char> create_npy_header(const T * /* data */, const unsigned int* shape, const unsigned int ndims, bool fortran_order)
-    {
-
-        std::vector<char> dict;
-        dict += "{'descr': '";
-        dict += BigEndianTest();
-        dict += map_type(typeid(T));
-        dict += tostring(sizeof(T));
-        if (fortran_order) {
-            dict += "', 'fortran_order': True, 'shape': (";
-        } else {
-            dict += "', 'fortran_order': False, 'shape': (";
-        }
-        dict += tostring(shape[0]);
-        for(size_t i = 1; i < ndims; ++i) {
-            dict += ", ";
-            dict += tostring(shape[i]);
-        }
-        if(ndims == 1) dict += ",";
-        dict += "), }";
-        //pad with spaces so that preamble+dict is modulo 16 bytes. preamble is 10 bytes. dict needs to end with \n
-        int remainder = 16 - (10 + dict.size()) % 16;
-        dict.insert(dict.end(), remainder, ' ');
-        dict.back() = '\n';
-
-        std::vector<char> header;
-        header += (char) 0x93;
-        header += "NUMPY";
-        header += (char) 0x01; //major version of numpy format
-        header += (char) 0x00; //minor version of numpy format
-        header += (unsigned short) dict.size();
-        header.insert(header.end(),dict.begin(),dict.end());
-
-        return header;
-    }
+  return header;
+}
 
 } // closes namespace
 
 cnpy::NpyArray load_the_npy_file(FILE * fp);
-
-#endif // LIBCNPY_H_


### PR DESCRIPTION
This PR modifies all header files to use [`#pragma once`](https://en.wikipedia.org/wiki/Pragma_once) to guard from multiple inclusion. This removes the arbitrary and error-prone task of finding a good name for the preprocessor guard to be used in the usual construct:
```
#ifndef UNIQUE_NAME
#define UNIQUE_NAME
/*
 Your code here
*/
#endif /* UNIQUE_NAME */
```

## Todos
* **Developer Interest**
  - [x] Use `#pragma once` in all header files
  - [x] Fix Git hooks for shebang and Py3 compatibility.
  - [x] Reformat some header files to comply with code style.

## Status
- [x]  Ready to go


