### PR TITLE
Format sources using clang-format and YAPF

### DIFF
--- a/include/Config.hpp.in
+++ b/include/Config.hpp.in
@@ -40,15 +40,15 @@
 #endif
 
 #ifdef __GNUC__
-#  define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
+#define UNUSED(x) UNUSED_##x __attribute__((__unused__))
 #else
-#  define UNUSED(x) UNUSED_ ## x
+#define UNUSED(x) UNUSED_##x
 #endif
 
 #ifdef __GNUC__
-#  define UNUSED_FUNCTION(x) __attribute__((__unused__)) UNUSED_ ## x
+#define UNUSED_FUNCTION(x) __attribute__((__unused__)) UNUSED_##x
 #else
-#  define UNUSED_FUNCTION(x) UNUSED_ ## x
+#define UNUSED_FUNCTION(x) UNUSED_##x
 #endif
 
 // Inspired from Eigen EIGEN_DEFAULT_DENSE_INDEX_TYPE

--- a/src/bin/debug_wavcav.cpp
+++ b/src/bin/debug_wavcav.cpp
@@ -21,15 +21,15 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 
 #include <Eigen/Core>
 
 #include "PWCSolver.hpp"
-#include "Vacuum.hpp"
 #include "UniformDielectric.hpp"
+#include "Vacuum.hpp"
 #include "WaveletCavity.hpp"
 
 int main(int argc, char ** argv) {

--- a/src/bin/run_pcm.cpp
+++ b/src/bin/run_pcm.cpp
@@ -21,8 +21,8 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#include <cstdlib>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <map>
@@ -40,8 +40,8 @@
 
 #include "interface/Input.hpp"
 #include "interface/Meddle.hpp"
-#include "utils/Molecule.hpp"
 #include "utils/ChargeDistribution.hpp"
+#include "utils/Molecule.hpp"
 
 std::ofstream pcmsolver_out;
 

--- a/src/cavity/Element.cpp
+++ b/src/cavity/Element.cpp
@@ -106,8 +106,7 @@ void Element::spherical_polygon(Eigen::Vector3d & t_,
     }
     numb[i] = i;
     phinumb[i] = phi[i];
-  jump:
-    ; // Do nothing...
+  jump:; // Do nothing...
   }
   numb[nVertices_] = numb[0];
   phinumb[nVertices_] = 2 * M_PI;

--- a/src/green/SphericalDiffuse.cpp
+++ b/src/green/SphericalDiffuse.cpp
@@ -39,9 +39,9 @@
 #include "GreenData.hpp"
 #include "GreensFunction.hpp"
 #include "cavity/Element.hpp"
-#include "utils/MathUtils.hpp"
 #include "dielectric_profile/ProfileTypes.hpp"
 #include "utils/ForId.hpp"
+#include "utils/MathUtils.hpp"
 
 namespace pcm {
 namespace green {

--- a/src/green/Vacuum.cpp
+++ b/src/green/Vacuum.cpp
@@ -41,8 +41,7 @@ using cavity::Element;
 using dielectric_profile::Uniform;
 namespace green {
 template <typename DerivativeTraits>
-Vacuum<DerivativeTraits>::Vacuum()
-    : GreensFunction<DerivativeTraits, Uniform>() {
+Vacuum<DerivativeTraits>::Vacuum() : GreensFunction<DerivativeTraits, Uniform>() {
   this->profile_ = Uniform(1.0);
 }
 

--- a/src/interface/Input.cpp
+++ b/src/interface/Input.cpp
@@ -25,21 +25,21 @@
 
 #include <iostream>
 #include <map>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "Config.hpp"
 
-#include <Eigen/Core>
 #include "utils/getkw/Getkw.h"
+#include <Eigen/Core>
 
 #include <boost/algorithm/string.hpp>
 
+#include "PCMInput.h"
 #include "bi_operators/BIOperatorData.hpp"
 #include "cavity/CavityData.hpp"
 #include "green/GreenData.hpp"
 #include "solver/SolverData.hpp"
-#include "PCMInput.h"
 #include "utils/Factory.hpp"
 #include "utils/Solvent.hpp"
 #include "utils/Sphere.hpp"
@@ -94,7 +94,8 @@ void Input::reader(const std::string & filename) {
       Eigen::Vector3d center;
       center = (Eigen::Vector3d() << spheresInput[j],
                 spheresInput[j + 1],
-                spheresInput[j + 2]).finished();
+                spheresInput[j + 2])
+                   .finished();
       Sphere sph(center, spheresInput[j + 3]);
       spheres_.push_back(sph);
       j += 4;

--- a/src/interface/Meddle.cpp
+++ b/src/interface/Meddle.cpp
@@ -21,9 +21,9 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#include "pcmsolver.h"
-#include "PCMInput.h"
 #include "Meddle.hpp"
+#include "PCMInput.h"
+#include "pcmsolver.h"
 
 #include <string>
 #include <vector>
@@ -36,19 +36,19 @@
 
 #include "bi_operators/BIOperatorData.hpp"
 #include "bi_operators/BoundaryIntegralOperator.hpp"
-#include "cavity/CavityData.hpp"
 #include "cavity/Cavity.hpp"
-#include "green/GreenData.hpp"
+#include "cavity/CavityData.hpp"
 #include "green/Green.hpp"
-#include "solver/SolverData.hpp"
+#include "green/GreenData.hpp"
 #include "solver/Solver.hpp"
+#include "solver/SolverData.hpp"
 
-#include "utils/Atom.hpp"
 #include "Citation.hpp"
-#include "utils/cnpy.hpp"
+#include "utils/Atom.hpp"
 #include "utils/Factory.hpp"
 #include "utils/Solvent.hpp"
 #include "utils/Sphere.hpp"
+#include "utils/cnpy.hpp"
 
 #ifndef AS_TYPE
 #define AS_TYPE(Type, Obj) reinterpret_cast<Type *>(Obj)

--- a/src/make_cmake_files.py
+++ b/src/make_cmake_files.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-
 #
 #  PCMSolver, an API for the Polarizable Continuum Model
 #  Copyright (C) 2017 Roberto Di Remigio, Luca Frediani and collaborators.
@@ -49,6 +48,7 @@ Options:
   -h --help                              Show this screen.
 """
 
+
 def glob_sources_cxx(dir_name):
     """Create a list of C++ headers and sources to be used in a CMakeLists.txt file."""
     headers = 'list(APPEND headers_list '
@@ -62,6 +62,7 @@ def glob_sources_cxx(dir_name):
     message = '# List of headers\n' + headers \
             + '# List of sources\n' + sources
     return message
+
 
 def glob_sources_c(dir_name):
     """Create a list of C headers and sources to be used in a CMakeLists.txt file."""
@@ -77,6 +78,7 @@ def glob_sources_c(dir_name):
             + '# List of sources\n' + sources
     return message
 
+
 def glob_sources_fortran(dir_name):
     """Create a list of Fortran sources to be used in a CMakeLists.txt file."""
     types = ('*.f', '*.F', '*.f77', '*.F77', '*.f90', '*.F90')
@@ -90,6 +92,7 @@ def glob_sources_fortran(dir_name):
     message = '# List of sources\n' + sources
     return message
 
+
 try:
     arguments = docopt.docopt(options, argv=None)
 except docopt.DocoptExit:
@@ -99,7 +102,7 @@ except docopt.DocoptExit:
 
 # Grab command-line arguments
 libname = arguments['--libname']
-lang    = arguments['--lang']
+lang = arguments['--lang']
 
 root_directory = os.getcwd()
 dname = os.path.join(root_directory, libname)

--- a/src/solver/CPCMSolver.cpp
+++ b/src/solver/CPCMSolver.cpp
@@ -34,8 +34,8 @@
 
 #include "SolverData.hpp"
 #include "bi_operators/IBoundaryIntegralOperator.hpp"
-#include "cavity/ICavity.hpp"
 #include "cavity/Element.hpp"
+#include "cavity/ICavity.hpp"
 #include "green/IGreensFunction.hpp"
 #include "utils/MathUtils.hpp"
 

--- a/src/solver/IEFSolver.cpp
+++ b/src/solver/IEFSolver.cpp
@@ -23,9 +23,9 @@
 
 #include "IEFSolver.hpp"
 
-#include <iostream>
 #include <cmath>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -34,13 +34,13 @@
 #include <Eigen/Core>
 #include <Eigen/LU>
 
-#include "bi_operators/IBoundaryIntegralOperator.hpp"
-#include "cavity/ICavity.hpp"
-#include "cavity/Element.hpp"
-#include "green/IGreensFunction.hpp"
-#include "utils/MathUtils.hpp"
 #include "SolverData.hpp"
 #include "SolverImpl.hpp"
+#include "bi_operators/IBoundaryIntegralOperator.hpp"
+#include "cavity/Element.hpp"
+#include "cavity/ICavity.hpp"
+#include "green/IGreensFunction.hpp"
+#include "utils/MathUtils.hpp"
 
 namespace pcm {
 namespace solver {

--- a/src/solver/SolverImpl.cpp
+++ b/src/solver/SolverImpl.cpp
@@ -32,8 +32,8 @@
 #include <Eigen/LU>
 
 #include "bi_operators/IBoundaryIntegralOperator.hpp"
-#include "cavity/ICavity.hpp"
 #include "cavity/Element.hpp"
+#include "cavity/ICavity.hpp"
 #include "green/IGreensFunction.hpp"
 
 namespace pcm {

--- a/src/utils/ChargeDistribution.cpp
+++ b/src/utils/ChargeDistribution.cpp
@@ -21,8 +21,8 @@
  * PCMSolver API, see: <http://pcmsolver.readthedocs.io/>
  */
 
-#include <iostream>
 #include "ChargeDistribution.hpp"
+#include <iostream>
 
 #include "Config.hpp"
 

--- a/src/utils/Interpolation.cpp
+++ b/src/utils/Interpolation.cpp
@@ -1,66 +1,87 @@
-#include "Vector3.hpp"
 #include "Vector2.hpp"
+#include "Vector3.hpp"
 #include <stdlib.h>
 #include <string.h>
 #ifdef DEBUG
-  #include <cstdio>
+#include <cstdio>
 #endif
 #include "Interpolation.hpp"
-Interpolation::Interpolation(Vector3*** U, int gradeIn, const int /* type */, unsigned int nLevelsIn, unsigned int noPatchIn){
+Interpolation::Interpolation(Vector3 *** U,
+                             int gradeIn,
+                             const int /* type */,
+                             unsigned int nLevelsIn,
+                             unsigned int noPatchIn) {
   noPatch = noPatchIn;
-  n = 1<<(nLevelsIn-gradeIn);
-  grade = (1<<gradeIn);
-  coeff = (Vector3*) malloc(sizeof(Vector3)*(grade+1));
-  if (gradeIn < 0) grade = 0;
-  h = 1./grade;
-  if (grade == 0) n = 1<<(nLevelsIn);
+  n = 1 << (nLevelsIn - gradeIn);
+  grade = (1 << gradeIn);
+  coeff = (Vector3 *)malloc(sizeof(Vector3) * (grade + 1));
+  if (gradeIn < 0)
+    grade = 0;
+  h = 1. / grade;
+  if (grade == 0)
+    n = 1 << (nLevelsIn);
   unsigned int i1, i2, i3, iSize, el;
   unsigned int i;
 
-  //initialization -- maybe allocate in one go
-  pSurfaceInterpolation = (Vector3****) malloc(noPatch*sizeof
-      (Vector3***));//+noPatch*n*(Vector3**) + noPatch*n*n*(Vector3*) + noPatch*n*n*(grade+*(grade+1)*(Vector3));
-  for (i1=0; i1<noPatch; i1++){
-    pSurfaceInterpolation[i1] = (Vector3***) malloc(n*sizeof(Vector3**) + n*n*sizeof
-        (Vector3*) + n*n*(grade+1)*(grade+1)*sizeof(Vector3));
-    for (i2=0; i2 < n; ++i2) { // rowwise counting of the patch zi = (i1,i2,i3)
-      pSurfaceInterpolation[i1][i2] = (Vector3**) (pSurfaceInterpolation[i1]+n)+i2*n;
-      for (i3=0; i3<n; ++i3) 	{
-        pSurfaceInterpolation[i1][i2][i3] = (Vector3*) (pSurfaceInterpolation[i1]+n+n*n)
-          +i2*n*(grade+1)*(grade+1) + i3*(grade+1)*(grade+1);
+  // initialization -- maybe allocate in one go
+  pSurfaceInterpolation =
+      (Vector3 ****)malloc(noPatch * sizeof(Vector3 ***)); //+noPatch*n*(Vector3**) +
+  // noPatch*n*n*(Vector3*) +
+  // noPatch*n*n*(grade+*(grade+1)*(Vector3));
+  for (i1 = 0; i1 < noPatch; i1++) {
+    pSurfaceInterpolation[i1] =
+        (Vector3 ***)malloc(n * sizeof(Vector3 **) + n * n * sizeof(Vector3 *) +
+                            n * n * (grade + 1) * (grade + 1) * sizeof(Vector3));
+    for (i2 = 0; i2 < n; ++i2) { // rowwise counting of the patch zi = (i1,i2,i3)
+      pSurfaceInterpolation[i1][i2] =
+          (Vector3 **)(pSurfaceInterpolation[i1] + n) + i2 * n;
+      for (i3 = 0; i3 < n; ++i3) {
+        pSurfaceInterpolation[i1][i2][i3] =
+            (Vector3 *)(pSurfaceInterpolation[i1] + n + n * n) +
+            i2 * n * (grade + 1) * (grade + 1) + i3 * (grade + 1) * (grade + 1);
         for (iSize = 0; iSize <= grade; iSize++) {
-          for( el = 0; el <= grade; el++) {
-            //calculate 1D interpolation polinomials
-            if(grade == 0) {
-							pSurfaceInterpolation[i1][i2][i3][(grade+1)*iSize+el] = U[i1][i2][i3];
-						} else {
-							pSurfaceInterpolation[i1][i2][i3][(grade+1)*iSize+el] =
-                U[i1][grade*i2+iSize][grade*i3+el];
-						}
-					}
+          for (el = 0; el <= grade; el++) {
+            // calculate 1D interpolation polinomials
+            if (grade == 0) {
+              pSurfaceInterpolation[i1][i2][i3][(grade + 1) * iSize + el] =
+                  U[i1][i2][i3];
+            } else {
+              pSurfaceInterpolation[i1][i2][i3][(grade + 1) * iSize + el] =
+                  U[i1][grade * i2 + iSize][grade * i3 + el];
+            }
+          }
         }
-        if(grade!=0) {
-					for (iSize = 0; iSize <= grade; iSize++) {
-						for( el = 1; el <= grade; el++) {
-							for(i = grade; i >= el; --i) {
-								pSurfaceInterpolation[i1][i2][i3][(grade+1)*iSize+i] = vector3SMul(1./(h*el),
-                    vector3Sub(pSurfaceInterpolation[i1][i2][i3][(grade+1)*iSize+i],
-                      pSurfaceInterpolation[i1][i2][i3][(grade+1)*iSize+i-1]));
-							}
-						}
-					}
-					for(iSize = 1; iSize <= grade; ++iSize) {
-						// column iSize - Newton Scheme on each column
-						for(el = 0; el <= grade; ++el) {
-							// Newton Scheme for calculating interpolation polinomial
-							for( i = grade; i >= iSize; --i) {
-								pSurfaceInterpolation[i1][i2][i3][(grade+1)*i+el]= vector3SMul(1./(h*iSize),
-                    vector3Sub(pSurfaceInterpolation[i1][i2][i3][(grade+1)*i+el],
-                      pSurfaceInterpolation[i1][i2][i3][(grade+1)*(i-1)+el]));
-							}
-						}
-					}
-				}
+        if (grade != 0) {
+          for (iSize = 0; iSize <= grade; iSize++) {
+            for (el = 1; el <= grade; el++) {
+              for (i = grade; i >= el; --i) {
+                pSurfaceInterpolation[i1][i2][i3][(grade + 1) * iSize + i] =
+                    vector3SMul(
+                        1. / (h * el),
+                        vector3Sub(
+                            pSurfaceInterpolation[i1][i2][i3]
+                                                 [(grade + 1) * iSize + i],
+                            pSurfaceInterpolation[i1][i2][i3]
+                                                 [(grade + 1) * iSize + i - 1]));
+              }
+            }
+          }
+          for (iSize = 1; iSize <= grade; ++iSize) {
+            // column iSize - Newton Scheme on each column
+            for (el = 0; el <= grade; ++el) {
+              // Newton Scheme for calculating interpolation polinomial
+              for (i = grade; i >= iSize; --i) {
+                pSurfaceInterpolation[i1][i2][i3][(grade + 1) * i + el] =
+                    vector3SMul(
+                        1. / (h * iSize),
+                        vector3Sub(
+                            pSurfaceInterpolation[i1][i2][i3][(grade + 1) * i + el],
+                            pSurfaceInterpolation[i1][i2][i3]
+                                                 [(grade + 1) * (i - 1) + el]));
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -68,21 +89,26 @@ Interpolation::Interpolation(Vector3*** U, int gradeIn, const int /* type */, un
   FILE * debugFile = fopen("debug.out", "a");
   fprintf(debugFile, ">>> INTERPOLATION_POLINOMIALS\n");
   fprintf(debugFile, "%d %lf\n", grade, h);
-  for (i1=0; i1<noPatch; ++i1) {
-    for (i2=0; i2 < n; ++i2) { // rowwise counting of the patch zi = (i1,i2,i3)
-      for (i3=0; i3<n; ++i3) 	{
+  for (i1 = 0; i1 < noPatch; ++i1) {
+    for (i2 = 0; i2 < n; ++i2) { // rowwise counting of the patch zi = (i1,i2,i3)
+      for (i3 = 0; i3 < n; ++i3) {
         for (iSize = 0; iSize <= grade; iSize++) {
-          for( el = 0; el <= grade; el++) {
-            fprintf(debugFile, "%d %d %d  %d %lf %lf %lf\n",i1, i2, i3, (grade+1)*iSize+el,
-                pSurfaceInterpolation[i1][i2][i3][(grade+1)*iSize+el].x,
-                pSurfaceInterpolation[i1][i2][i3][(grade+1)*iSize+el].y,
-                pSurfaceInterpolation[i1][i2][i3][(grade+1)*iSize+el].z);
-					}
-				}
-				fprintf(debugFile, "\n");
-			}
-		}
-	}
+          for (el = 0; el <= grade; el++) {
+            fprintf(debugFile,
+                    "%d %d %d  %d %lf %lf %lf\n",
+                    i1,
+                    i2,
+                    i3,
+                    (grade + 1) * iSize + el,
+                    pSurfaceInterpolation[i1][i2][i3][(grade + 1) * iSize + el].x,
+                    pSurfaceInterpolation[i1][i2][i3][(grade + 1) * iSize + el].y,
+                    pSurfaceInterpolation[i1][i2][i3][(grade + 1) * iSize + el].z);
+          }
+        }
+        fprintf(debugFile, "\n");
+      }
+    }
+  }
   fprintf(debugFile, "<<< INTERPOLATION_POLINOMIALS\n");
   fclose(debugFile);
 #endif
@@ -90,362 +116,398 @@ Interpolation::Interpolation(Vector3*** U, int gradeIn, const int /* type */, un
 }
 
 // calculate the value in one point
-Vector3 Interpolation::Chi(Vector2 a, int patch){
-	unsigned int x, y;
+Vector3 Interpolation::Chi(Vector2 a, int patch) {
+  unsigned int x, y;
   Vector3 c(0.0, 0.0, 0.0), d(0.0, 0.0, 0.0);
 
-  x = (unsigned int) floor(a.x*n);
-  y = (unsigned int) floor(a.y*n);
+  x = (unsigned int)floor(a.x * n);
+  y = (unsigned int)floor(a.y * n);
 
-  if(x == n) --x;
-  if(y == n) --y;
-  a.x = n*a.x - floor(a.x*n);
-  a.y = n*a.y - floor(a.y*n);
-	//if(x > 0) if((grade*x/h - a.x)*(grade*x/h - a.x) < 1e-10) --x;
-  //if(y > 0) if((grade*y/h - a.y)*(grade*y/h - a.y) < 1e-10) --y;
+  if (x == n)
+    --x;
+  if (y == n)
+    --y;
+  a.x = n * a.x - floor(a.x * n);
+  a.y = n * a.y - floor(a.y * n);
+  // if(x > 0) if((grade*x/h - a.x)*(grade*x/h - a.x) < 1e-10) --x;
+  // if(y > 0) if((grade*y/h - a.y)*(grade*y/h - a.y) < 1e-10) --y;
 
-	c = pSurfaceInterpolation[patch][y][x][grade*(grade+1)+grade];
-	for(int j = grade-1; j >=0; --j) {
-		c = vector3SMul(a.x-j*h, c);
-		c = vector3Add(c, pSurfaceInterpolation[patch][y][x][grade*(grade+1)+j]);
-	}
+  c = pSurfaceInterpolation[patch][y][x][grade * (grade + 1) + grade];
+  for (int j = grade - 1; j >= 0; --j) {
+    c = vector3SMul(a.x - j * h, c);
+    c = vector3Add(c, pSurfaceInterpolation[patch][y][x][grade * (grade + 1) + j]);
+  }
 
-	for(int i = grade-1; i >=0; --i) {
-		d = pSurfaceInterpolation[patch][y][x][i*(grade+1)+grade];
-		for(int j = grade-1; j >=0; --j) {
-			d = vector3SMul(a.x-j*h, d);
-			d = vector3Add(d, pSurfaceInterpolation[patch][y][x][i*(grade+1)+j]);
-		}
-		c = vector3SMul(a.y-i*h,c);
-		c = vector3Add(c,d);
-	}
+  for (int i = grade - 1; i >= 0; --i) {
+    d = pSurfaceInterpolation[patch][y][x][i * (grade + 1) + grade];
+    for (int j = grade - 1; j >= 0; --j) {
+      d = vector3SMul(a.x - j * h, d);
+      d = vector3Add(d, pSurfaceInterpolation[patch][y][x][i * (grade + 1) + j]);
+    }
+    c = vector3SMul(a.y - i * h, c);
+    c = vector3Add(c, d);
+  }
   return c;
 }
 
 // calculate the x derivative in one point
-Vector3 Interpolation::dChi_dx(Vector2 a, int patch){
+Vector3 Interpolation::dChi_dx(Vector2 a, int patch) {
   unsigned int x, y;
 
-  Vector3 c(0.0,0.0,0.0), dc_dx(0.0,0.0,0.0);
+  Vector3 c(0.0, 0.0, 0.0), dc_dx(0.0, 0.0, 0.0);
 
-  x = (unsigned int)floor(a.x*n);
-  y = (unsigned int)floor(a.y*n);
+  x = (unsigned int)floor(a.x * n);
+  y = (unsigned int)floor(a.y * n);
 
-  //if(x > 0) if((grade*x/h - a.x)*(grade*x/h - a.x) < 1e-10) --x;
-  //if(y > 0) if((grade*y/h - a.y)*(grade*y/h - a.y) < 1e-10) --y;
+  // if(x > 0) if((grade*x/h - a.x)*(grade*x/h - a.x) < 1e-10) --x;
+  // if(y > 0) if((grade*y/h - a.y)*(grade*y/h - a.y) < 1e-10) --y;
   /** @note that here there are two possibilities to adjust the "corner"
    * points, either they belong to the old interpolation or the new one. In my
    * case I chose to make it belong to the new one, except of course for the
    * last points which are here assigned to the old interpolation polinomial
    */
-  if(x == n) --x;
-  if(y == n) --y;
-  a.x = n*a.x - floor(a.x*n);
-  a.y = n*a.y - floor(a.y*n);
+  if (x == n)
+    --x;
+  if (y == n)
+    --y;
+  a.x = n * a.x - floor(a.x * n);
+  a.y = n * a.y - floor(a.y * n);
 
-  coeff[grade] = pSurfaceInterpolation[patch][y][x][grade*(grade+1)+grade];
+  coeff[grade] = pSurfaceInterpolation[patch][y][x][grade * (grade + 1) + grade];
   dc_dx = coeff[grade];
-	for(int j = grade-1; j >=1; --j) {
-    coeff[j] = vector3Add( pSurfaceInterpolation[patch][y][x][grade*(grade+1)+j],vector3SMul((a.x-j*h), coeff[j+1]));
-		dc_dx = vector3SMul(a.x-(j-1)*h, dc_dx);
-		dc_dx = vector3Add(dc_dx, coeff[j]);
-	}
+  for (int j = grade - 1; j >= 1; --j) {
+    coeff[j] =
+        vector3Add(pSurfaceInterpolation[patch][y][x][grade * (grade + 1) + j],
+                   vector3SMul((a.x - j * h), coeff[j + 1]));
+    dc_dx = vector3SMul(a.x - (j - 1) * h, dc_dx);
+    dc_dx = vector3Add(dc_dx, coeff[j]);
+  }
 
-	for(int i = grade-1; i >=0; --i) {
-    coeff[grade] = pSurfaceInterpolation[patch][y][x][i*(grade+1)+grade];
-		c = coeff[grade];
-		for(int j = grade-1; j >=1; --j) {
-      coeff[j] = vector3Add(pSurfaceInterpolation[patch][y][x][i*(grade+1)+j],vector3SMul((a.x-j*h), coeff[j+1]));
-			c = vector3SMul(a.x-(j-1)*h, c);
-			c = vector3Add(c, coeff[j]);
-		}
-		dc_dx = vector3SMul(a.y-i*h,dc_dx);
-		dc_dx = vector3Add(dc_dx,c);
-	}
-  dc_dx = vector3SMul(n,dc_dx);
+  for (int i = grade - 1; i >= 0; --i) {
+    coeff[grade] = pSurfaceInterpolation[patch][y][x][i * (grade + 1) + grade];
+    c = coeff[grade];
+    for (int j = grade - 1; j >= 1; --j) {
+      coeff[j] = vector3Add(pSurfaceInterpolation[patch][y][x][i * (grade + 1) + j],
+                            vector3SMul((a.x - j * h), coeff[j + 1]));
+      c = vector3SMul(a.x - (j - 1) * h, c);
+      c = vector3Add(c, coeff[j]);
+    }
+    dc_dx = vector3SMul(a.y - i * h, dc_dx);
+    dc_dx = vector3Add(dc_dx, c);
+  }
+  dc_dx = vector3SMul(n, dc_dx);
   return dc_dx;
 }
 
 // calculate the y derivative in one point
-Vector3 Interpolation::dChi_dy(Vector2 a, int patch){
+Vector3 Interpolation::dChi_dy(Vector2 a, int patch) {
   unsigned int x, y;
 
-  Vector3 c(0.0,0.0,0.0), dc_dx(0.0,0.0,0.0), dc_dy(0.0,0.0,0.0), res(0.0,0.0,0.0);
+  Vector3 c(0.0, 0.0, 0.0), dc_dx(0.0, 0.0, 0.0), dc_dy(0.0, 0.0, 0.0),
+      res(0.0, 0.0, 0.0);
 
-  x = (unsigned int)floor(a.x*n);
-  y = (unsigned int)floor(a.y*n);
+  x = (unsigned int)floor(a.x * n);
+  y = (unsigned int)floor(a.y * n);
 
-  //if(x > 0) if((grade*x/h - a.x)*(grade*x/h - a.x) < 1e-10) --x;
-  //if(y > 0) if((grade*y/h - a.y)*(grade*y/h - a.y) < 1e-10) --y;
+  // if(x > 0) if((grade*x/h - a.x)*(grade*x/h - a.x) < 1e-10) --x;
+  // if(y > 0) if((grade*y/h - a.y)*(grade*y/h - a.y) < 1e-10) --y;
   /** @note that here there are two possibilities to adjust the "corner"
    * points, either they belong to the old interpolation or the new one. In my
    * case I chose to make it belong to the new one, except of course for the
    * last points which are here assigned to the old interpolation polinomial
    */
-  if(x == n) --x;
-  if(y == n) --y;
-  a.x = n*a.x - floor(a.x*n);
-  a.y = n*a.y - floor(a.y*n);
+  if (x == n)
+    --x;
+  if (y == n)
+    --y;
+  a.x = n * a.x - floor(a.x * n);
+  a.y = n * a.y - floor(a.y * n);
 
-  coeff[grade] = pSurfaceInterpolation[patch][y][x][grade*(grade+1)+grade];
+  coeff[grade] = pSurfaceInterpolation[patch][y][x][grade * (grade + 1) + grade];
   dc_dy = coeff[grade];
-	for(int j = grade-1; j >=0; --j) {
-    coeff[j] = pSurfaceInterpolation[patch][y][x][grade*(grade+1)+j];
-		dc_dy = vector3SMul(a.x-((j)*h), dc_dy);
-		dc_dy = vector3Add(dc_dy, coeff[j]);
-	}
+  for (int j = grade - 1; j >= 0; --j) {
+    coeff[j] = pSurfaceInterpolation[patch][y][x][grade * (grade + 1) + j];
+    dc_dy = vector3SMul(a.x - ((j)*h), dc_dy);
+    dc_dy = vector3Add(dc_dy, coeff[j]);
+  }
 
-	for(int i = grade-1; i >=1; --i) {
-    coeff[grade] = vector3Add(pSurfaceInterpolation[patch][y][x][i*(grade+1)+grade],vector3SMul((a.y-(i)*h),coeff[grade]));
-		c = coeff[grade];
-		for(int j = grade-1; j >=0; --j) {
-      coeff[j] = vector3Add(pSurfaceInterpolation[patch][y][x][i*(grade+1)+j],vector3SMul((a.y-(i)*h),coeff[j]));
-			c = vector3SMul(a.x-(j)*h, c);
-			c = vector3Add(c, coeff[j]);
-		}
-		dc_dy = vector3SMul(a.y-(i-1)*h,dc_dy);
-		dc_dy = vector3Add(dc_dy,c);
-	}
-  dc_dy = vector3SMul(n,dc_dy);
+  for (int i = grade - 1; i >= 1; --i) {
+    coeff[grade] =
+        vector3Add(pSurfaceInterpolation[patch][y][x][i * (grade + 1) + grade],
+                   vector3SMul((a.y - (i)*h), coeff[grade]));
+    c = coeff[grade];
+    for (int j = grade - 1; j >= 0; --j) {
+      coeff[j] = vector3Add(pSurfaceInterpolation[patch][y][x][i * (grade + 1) + j],
+                            vector3SMul((a.y - (i)*h), coeff[j]));
+      c = vector3SMul(a.x - (j)*h, c);
+      c = vector3Add(c, coeff[j]);
+    }
+    dc_dy = vector3SMul(a.y - (i - 1) * h, dc_dy);
+    dc_dy = vector3Add(dc_dy, c);
+  }
+  dc_dy = vector3SMul(n, dc_dy);
   return dc_dy;
 }
 
 // calculate the y second derivative in one point
-Vector3 Interpolation::d2Chi_dy2(Vector2 a, int patch){
+Vector3 Interpolation::d2Chi_dy2(Vector2 a, int patch) {
   unsigned int x, y;
   double s, s1, p;
 
-  Vector3 dc_dx(0.0,0.0,0.0), res(0.0,0.0,0.0);
+  Vector3 dc_dx(0.0, 0.0, 0.0), res(0.0, 0.0, 0.0);
 
-  x = (unsigned int)floor(a.x*n);
-  y = (unsigned int)floor(a.y*n);
+  x = (unsigned int)floor(a.x * n);
+  y = (unsigned int)floor(a.y * n);
 
-  //if(x > 0) if((grade*x/h - a.x)*(grade*x/h - a.x) < 1e-10) --x;
-  //if(y > 0) if((grade*y/h - a.y)*(grade*y/h - a.y) < 1e-10) --y;
+  // if(x > 0) if((grade*x/h - a.x)*(grade*x/h - a.x) < 1e-10) --x;
+  // if(y > 0) if((grade*y/h - a.y)*(grade*y/h - a.y) < 1e-10) --y;
   /** @note that here there are two possibilities to adjust the "corner"
    * points, either they belong to the old interpolation or the new one. In my
    * case I chose to make it belong to the new one, except of course for the
    * last points which are here assigned to the old interpolation polinomial
    */
-  if(x == n) --x;
-  if(y == n) --y;
-  a.x = n*a.x - floor(a.x*n);
-  a.y = n*a.y - floor(a.y*n);
+  if (x == n)
+    --x;
+  if (y == n)
+    --y;
+  a.x = n * a.x - floor(a.x * n);
+  a.y = n * a.y - floor(a.y * n);
 
-  for(unsigned int dy = 2; dy <= grade; dy++){
-		res = pSurfaceInterpolation[patch][y][x][dy*(grade+1)+grade];
-		for(int j = grade-1; j >=0; --j){
-			res = vector3SMul(a.x-j*h, res);
-			res = vector3Add(res, pSurfaceInterpolation[patch][y][x][dy*(grade+1)+j]);
-		}
-		s = 0;
-		for(unsigned int j = 0; j <= dy-1; ++j){
-			s1 = 0;
-      for(unsigned int k = 0; k <= dy-1; ++k){
-        if ( k != j) {
+  for (unsigned int dy = 2; dy <= grade; dy++) {
+    res = pSurfaceInterpolation[patch][y][x][dy * (grade + 1) + grade];
+    for (int j = grade - 1; j >= 0; --j) {
+      res = vector3SMul(a.x - j * h, res);
+      res =
+          vector3Add(res, pSurfaceInterpolation[patch][y][x][dy * (grade + 1) + j]);
+    }
+    s = 0;
+    for (unsigned int j = 0; j <= dy - 1; ++j) {
+      s1 = 0;
+      for (unsigned int k = 0; k <= dy - 1; ++k) {
+        if (k != j) {
           p = 1;
-			    for(unsigned int i = 0; i <=dy-1; ++i){
-				    if((j!=i) && (i != k)){
-					    p *= (a.y-i*h);
+          for (unsigned int i = 0; i <= dy - 1; ++i) {
+            if ((j != i) && (i != k)) {
+              p *= (a.y - i * h);
             }
           }
-          s1+=p;
-				}
-			}
-			s+=s1;
-		}
-		dc_dx =vector3Add(dc_dx, vector3SMul(s,res));
-	}
+          s1 += p;
+        }
+      }
+      s += s1;
+    }
+    dc_dx = vector3Add(dc_dx, vector3SMul(s, res));
+  }
 
   return dc_dx;
 }
 
 // calculate the second derivative in x in one point
-Vector3 Interpolation::d2Chi_dx2(Vector2 a, int patch){
+Vector3 Interpolation::d2Chi_dx2(Vector2 a, int patch) {
   unsigned int x, y;
   double s, s1, p;
 
-  Vector3 c(0.0,0.0,0.0), dc_dx(0.0,0.0,0.0), dc_dy(0.0,0.0,0.0), res(0.0,0.0,0.0);
+  Vector3 c(0.0, 0.0, 0.0), dc_dx(0.0, 0.0, 0.0), dc_dy(0.0, 0.0, 0.0),
+      res(0.0, 0.0, 0.0);
 
-  x = (unsigned int)floor(a.x*n);
-  y = (unsigned int)floor(a.y*n);
-  memcpy(coeff, pSurfaceInterpolation[patch][y][x], (grade+1)*(grade+1)*sizeof(Vector3));
+  x = (unsigned int)floor(a.x * n);
+  y = (unsigned int)floor(a.y * n);
+  memcpy(coeff,
+         pSurfaceInterpolation[patch][y][x],
+         (grade + 1) * (grade + 1) * sizeof(Vector3));
 
-  //if(x > 0) if((grade*x/h - a.x)*(grade*x/h - a.x) < 1e-10) --x;
-  //if(y > 0) if((grade*y/h - a.y)*(grade*y/h - a.y) < 1e-10) --y;
+  // if(x > 0) if((grade*x/h - a.x)*(grade*x/h - a.x) < 1e-10) --x;
+  // if(y > 0) if((grade*y/h - a.y)*(grade*y/h - a.y) < 1e-10) --y;
   /** @note that here there are two possibilities to adjust the "corner"
    * points, either they belong to the old interpolation or the new one. In my
    * case I chose to make it belong to the new one, except of course for the
    * last points which are here assigned to the old interpolation polinomial
    */
-  if(x == n) --x;
-  if(y == n) --y;
-  a.x = n*a.x - floor(a.x*n);
-  a.y = n*a.y - floor(a.y*n);
+  if (x == n)
+    --x;
+  if (y == n)
+    --y;
+  a.x = n * a.x - floor(a.x * n);
+  a.y = n * a.y - floor(a.y * n);
 
-  for(unsigned int dy = 2; dy <= grade; dy++){
-		res = pSurfaceInterpolation[patch][y][x][grade*(grade+1)+dy];
-		for(int j = grade-1; j >=0; --j){
-			res = vector3SMul(a.y-j*h, res);
-			res = vector3Add(res, pSurfaceInterpolation[patch][y][x][j*(grade+1)+dy]);
-		}
-		s = 0;
-		for(unsigned int j = 0; j <= dy-1; ++j){
-			s1 = 0;
-      for(unsigned int k = 0; k <= dy-1; ++k){
-        if ( k != j) {
+  for (unsigned int dy = 2; dy <= grade; dy++) {
+    res = pSurfaceInterpolation[patch][y][x][grade * (grade + 1) + dy];
+    for (int j = grade - 1; j >= 0; --j) {
+      res = vector3SMul(a.y - j * h, res);
+      res =
+          vector3Add(res, pSurfaceInterpolation[patch][y][x][j * (grade + 1) + dy]);
+    }
+    s = 0;
+    for (unsigned int j = 0; j <= dy - 1; ++j) {
+      s1 = 0;
+      for (unsigned int k = 0; k <= dy - 1; ++k) {
+        if (k != j) {
           p = 1;
-			    for(unsigned int i = 0; i <=dy-1; ++i){
-				    if((j!=i) && (i != k)){
-					    p *= (a.x-i*h);
+          for (unsigned int i = 0; i <= dy - 1; ++i) {
+            if ((j != i) && (i != k)) {
+              p *= (a.x - i * h);
             }
           }
-          s1+=p;
-				}
-			}
-			s+=s1;
-		}
-		dc_dx =vector3Add(dc_dx, vector3SMul(s,res));
-	}
+          s1 += p;
+        }
+      }
+      s += s1;
+    }
+    dc_dx = vector3Add(dc_dx, vector3SMul(s, res));
+  }
 
   return dc_dx;
 }
 
 // calculate the second derivative in one point
-Vector3 Interpolation::d2Chi_dxy(Vector2 a, int patch){
+Vector3 Interpolation::d2Chi_dxy(Vector2 a, int patch) {
   unsigned int x, y;
-  double s,p, s2, p2;
+  double s, p, s2, p2;
 
-  Vector3 c(0.0,0.0,0.0), dc_dx(0.0,0.0,0.0), dc_dy(0.0,0.0,0.0), res(0.0,0.0,0.0);
+  Vector3 c(0.0, 0.0, 0.0), dc_dx(0.0, 0.0, 0.0), dc_dy(0.0, 0.0, 0.0),
+      res(0.0, 0.0, 0.0);
 
-  x = (unsigned int)floor(a.x*n);
-  y = (unsigned int)floor(a.y*n);
+  x = (unsigned int)floor(a.x * n);
+  y = (unsigned int)floor(a.y * n);
 
-  //if(x > 0) if((grade*x/h - a.x)*(grade*x/h - a.x) < 1e-10) --x;
-  //if(y > 0) if((grade*y/h - a.y)*(grade*y/h - a.y) < 1e-10) --y;
+  // if(x > 0) if((grade*x/h - a.x)*(grade*x/h - a.x) < 1e-10) --x;
+  // if(y > 0) if((grade*y/h - a.y)*(grade*y/h - a.y) < 1e-10) --y;
   /** @note that here there are two possibilities to adjust the "corner"
    * points, either they belong to the old interpolation or the new one. In my
    * case I chose to make it belong to the new one, except of course for the
    * last points which are here assigned to the old interpolation polinomial
    */
-  if(x == n) --x;
-  if(y == n) --y;
-  a.x = n*a.x - floor(a.x*n);
-  a.y = n*a.y - floor(a.y*n);
+  if (x == n)
+    --x;
+  if (y == n)
+    --y;
+  a.x = n * a.x - floor(a.x * n);
+  a.y = n * a.y - floor(a.y * n);
 
-	for(int dy = grade; dy >= 1; --dy){
-		res = pSurfaceInterpolation[patch][y][x][dy*(grade+1)+1];
-		// calculate the other elements
-		for(unsigned int der = 2; der <= grade; ++der){
-			//coefficient of pSurfaceInterpolation[y][x][grade*(grade+1)+grade];
-			s = 0;
-			for(int i = der-1; i >=0; --i){
-				// all combinations of i elements
-				p = 1;
-				for(unsigned int j = 0; j <=der-1; ++j){
-					if((int)j!=i){
-						p *= (a.x-j*h);
-					}
-				}
-				s+=p;
-			}
-			res = vector3Add(res, vector3SMul(s, pSurfaceInterpolation[patch][y][x][dy*(grade+1)+der]));
-		}
+  for (int dy = grade; dy >= 1; --dy) {
+    res = pSurfaceInterpolation[patch][y][x][dy * (grade + 1) + 1];
+    // calculate the other elements
+    for (unsigned int der = 2; der <= grade; ++der) {
+      // coefficient of pSurfaceInterpolation[y][x][grade*(grade+1)+grade];
+      s = 0;
+      for (int i = der - 1; i >= 0; --i) {
+        // all combinations of i elements
+        p = 1;
+        for (unsigned int j = 0; j <= der - 1; ++j) {
+          if ((int)j != i) {
+            p *= (a.x - j * h);
+          }
+        }
+        s += p;
+      }
+      res = vector3Add(
+          res,
+          vector3SMul(s,
+                      pSurfaceInterpolation[patch][y][x][dy * (grade + 1) + der]));
+    }
     s2 = 0;
-    for(int i = dy-1; i >=0; --i){
+    for (int i = dy - 1; i >= 0; --i) {
       // all combinations of i elements
       p2 = 1;
-      for(int j = 0; j <=dy-1;++j){
-        if(j!=i){
-          p2*=(a.y-j*h);
+      for (int j = 0; j <= dy - 1; ++j) {
+        if (j != i) {
+          p2 *= (a.y - j * h);
         }
       }
-      s2+=p2;
+      s2 += p2;
     }
-		//dc_dy = vector3SMul((a.y-dy*h),dc_dy);
-		res = vector3SMul(s2,res);
-		dc_dy = vector3Add(res,dc_dy);
-	}
+    // dc_dy = vector3SMul((a.y-dy*h),dc_dy);
+    res = vector3SMul(s2, res);
+    dc_dy = vector3Add(res, dc_dy);
+  }
 
   return dc_dy;
 }
 // calculate the normal in one point
-Vector3 Interpolation::n_Chi(Vector2 a, int patch){
+Vector3 Interpolation::n_Chi(Vector2 a, int patch) {
   unsigned int x, y;
 
-  Vector3 c(0.0,0.0,0.0), dc_dx(0.0,0.0,0.0), dc_dy(0.0,0.0,0.0), res(0.0,0.0,0.0);
+  Vector3 c(0.0, 0.0, 0.0), dc_dx(0.0, 0.0, 0.0), dc_dy(0.0, 0.0, 0.0),
+      res(0.0, 0.0, 0.0);
 
-  x = floor(a.x*n);
-  y = floor(a.y*n);
+  x = floor(a.x * n);
+  y = floor(a.y * n);
 
-  //if(x > 0) if((grade*x/h - a.x)*(grade*x/h - a.x) < 1e-10) --x;
-  //if(y > 0) if((grade*y/h - a.y)*(grade*y/h - a.y) < 1e-10) --y;
+  // if(x > 0) if((grade*x/h - a.x)*(grade*x/h - a.x) < 1e-10) --x;
+  // if(y > 0) if((grade*y/h - a.y)*(grade*y/h - a.y) < 1e-10) --y;
   /** @note that here there are two possibilities to adjust the "corner"
    * points, either they belong to the old interpolation or the new one. In my
    * case I chose to make it belong to the new one, except of course for the
    * last points which are here assigned to the old interpolation polinomial
    */
-  if(x == n) --x;
-  if(y == n) --y;
-  a.x = n*a.x - floor(a.x*n);
-  a.y = n*a.y - floor(a.y*n);
+  if (x == n)
+    --x;
+  if (y == n)
+    --y;
+  a.x = n * a.x - floor(a.x * n);
+  a.y = n * a.y - floor(a.y * n);
 
-  coeff[grade] = pSurfaceInterpolation[patch][y][x][grade*(grade+1)+grade];
+  coeff[grade] = pSurfaceInterpolation[patch][y][x][grade * (grade + 1) + grade];
   dc_dy = coeff[grade];
-	for(int j = grade-1; j >=0; --j) {
-    coeff[j] = pSurfaceInterpolation[patch][y][x][grade*(grade+1)+j];
-		dc_dy = vector3SMul(a.x-((j)*h), dc_dy);
-		dc_dy = vector3Add(dc_dy, coeff[j]);
-	}
+  for (int j = grade - 1; j >= 0; --j) {
+    coeff[j] = pSurfaceInterpolation[patch][y][x][grade * (grade + 1) + j];
+    dc_dy = vector3SMul(a.x - ((j)*h), dc_dy);
+    dc_dy = vector3Add(dc_dy, coeff[j]);
+  }
 
-	for(int i = grade-1; i >=1; --i) {
-    coeff[grade] = vector3Add(pSurfaceInterpolation[patch][y][x][i*(grade+1)+grade],vector3SMul((a.y-(i)*h),coeff[grade]));
-		c = coeff[grade];
-		for(int j = grade-1; j >=0; --j) {
-      coeff[j] = vector3Add(pSurfaceInterpolation[patch][y][x][i*(grade+1)+j],vector3SMul((a.y-(i)*h),coeff[j]));
-			c = vector3SMul(a.x-(j)*h, c);
-			c = vector3Add(c, coeff[j]);
-		}
-		dc_dy = vector3SMul(a.y-(i-1)*h,dc_dy);
-		dc_dy = vector3Add(dc_dy,c);
-	}
-  dc_dy = vector3SMul(n,dc_dy);
+  for (int i = grade - 1; i >= 1; --i) {
+    coeff[grade] =
+        vector3Add(pSurfaceInterpolation[patch][y][x][i * (grade + 1) + grade],
+                   vector3SMul((a.y - (i)*h), coeff[grade]));
+    c = coeff[grade];
+    for (int j = grade - 1; j >= 0; --j) {
+      coeff[j] = vector3Add(pSurfaceInterpolation[patch][y][x][i * (grade + 1) + j],
+                            vector3SMul((a.y - (i)*h), coeff[j]));
+      c = vector3SMul(a.x - (j)*h, c);
+      c = vector3Add(c, coeff[j]);
+    }
+    dc_dy = vector3SMul(a.y - (i - 1) * h, dc_dy);
+    dc_dy = vector3Add(dc_dy, c);
+  }
+  dc_dy = vector3SMul(n, dc_dy);
 
-  coeff[grade] = pSurfaceInterpolation[patch][y][x][grade*(grade+1)+grade];
+  coeff[grade] = pSurfaceInterpolation[patch][y][x][grade * (grade + 1) + grade];
   dc_dx = coeff[grade];
-	for(int j = grade-1; j >=1; --j) {
-    coeff[j] = vector3Add( pSurfaceInterpolation[patch][y][x][grade*(grade+1)+j],vector3SMul((a.x-(j)*h), coeff[j+1]));
-		dc_dx = vector3SMul(a.x-((j-1)*h), dc_dx);
-		dc_dx = vector3Add(dc_dx, coeff[j]);
-	}
+  for (int j = grade - 1; j >= 1; --j) {
+    coeff[j] =
+        vector3Add(pSurfaceInterpolation[patch][y][x][grade * (grade + 1) + j],
+                   vector3SMul((a.x - (j)*h), coeff[j + 1]));
+    dc_dx = vector3SMul(a.x - ((j - 1) * h), dc_dx);
+    dc_dx = vector3Add(dc_dx, coeff[j]);
+  }
 
-	for(int i = grade-1; i >=0; --i) {
-    coeff[grade] = pSurfaceInterpolation[patch][y][x][i*(grade+1)+grade];
-		c = coeff[grade];
-		for(int j = grade-1; j >=1; --j) {
-      coeff[j] = vector3Add(pSurfaceInterpolation[patch][y][x][i*(grade+1)+j],vector3SMul((a.x-(j)*h), coeff[j+1]));
-			c = vector3SMul(a.x-(j-1)*h, c);
-			c = vector3Add(c, coeff[j]);
-		}
-		dc_dx = vector3SMul(a.y-(i)*h,dc_dx);
-		dc_dx = vector3Add(dc_dx,c);
-	}
-  dc_dx = vector3SMul(n,dc_dx);
+  for (int i = grade - 1; i >= 0; --i) {
+    coeff[grade] = pSurfaceInterpolation[patch][y][x][i * (grade + 1) + grade];
+    c = coeff[grade];
+    for (int j = grade - 1; j >= 1; --j) {
+      coeff[j] = vector3Add(pSurfaceInterpolation[patch][y][x][i * (grade + 1) + j],
+                            vector3SMul((a.x - (j)*h), coeff[j + 1]));
+      c = vector3SMul(a.x - (j - 1) * h, c);
+      c = vector3Add(c, coeff[j]);
+    }
+    dc_dx = vector3SMul(a.y - (i)*h, dc_dx);
+    dc_dx = vector3Add(dc_dx, c);
+  }
+  dc_dx = vector3SMul(n, dc_dx);
 
-	//c.x = (dc_dy.y*dc_dx.z - dc_dy.z*dc_dx.y);
-	//c.y = (dc_dy.z*dc_dx.x - dc_dy.x*dc_dx.z);
-	//c.z = (dc_dy.x*dc_dx.y - dc_dy.y*dc_dx.x);
-	c.x = (dc_dy.z*dc_dx.y - dc_dy.y*dc_dx.z);
-	c.y = (dc_dy.x*dc_dx.z - dc_dy.z*dc_dx.x);
-	c.z = (dc_dy.y*dc_dx.x - dc_dy.x*dc_dx.y);
+  // c.x = (dc_dy.y*dc_dx.z - dc_dy.z*dc_dx.y);
+  // c.y = (dc_dy.z*dc_dx.x - dc_dy.x*dc_dx.z);
+  // c.z = (dc_dy.x*dc_dx.y - dc_dy.y*dc_dx.x);
+  c.x = (dc_dy.z * dc_dx.y - dc_dy.y * dc_dx.z);
+  c.y = (dc_dy.x * dc_dx.z - dc_dy.z * dc_dx.x);
+  c.z = (dc_dy.y * dc_dx.x - dc_dy.x * dc_dx.y);
 
   return c;
 }
 
-Interpolation::~Interpolation(){
-  for(unsigned int i = 0; i < noPatch; ++i) free(pSurfaceInterpolation[i]);
+Interpolation::~Interpolation() {
+  for (unsigned int i = 0; i < noPatch; ++i)
+    free(pSurfaceInterpolation[i]);
   free(pSurfaceInterpolation);
   free(coeff);
 }
-
-

--- a/src/utils/Molecule.cpp
+++ b/src/utils/Molecule.cpp
@@ -24,11 +24,11 @@
 #include "Molecule.hpp"
 
 #include <algorithm>
+#include <cmath>
+#include <iomanip>
 #include <iostream>
 #include <string>
 #include <vector>
-#include <cmath>
-#include <iomanip>
 
 #include "Config.hpp"
 
@@ -38,9 +38,9 @@
 #include <Eigen/Eigenvalues>
 
 #include "Atom.hpp"
-#include "cavity/Element.hpp"
 #include "MathUtils.hpp"
 #include "Symmetry.hpp"
+#include "cavity/Element.hpp"
 
 namespace pcm {
 using cavity::Element;

--- a/src/utils/getkw/Getkw.cpp
+++ b/src/utils/getkw/Getkw.cpp
@@ -9,335 +9,321 @@
 
 #include "Getkw.h"
 
-#define TEST_ARRAY if (len > 1) \
-	std::cout << "Warning, invalid length of 1 for " << name << std::endl;
+#define TEST_ARRAY                                                                  \
+  if (len > 1)                                                                      \
+    std::cout << "Warning, invalid length of 1 for " << name << std::endl;
 
 using namespace std;
 
-Getkw::Getkw(const string file, bool _verbose, bool _strict):
-		verbose(_verbose), strict(_strict) {
+Getkw::Getkw(const string file, bool _verbose, bool _strict)
+    : verbose(_verbose), strict(_strict) {
 
-	toplevel = 0;
-	if (file.empty() != 0 || file.compare("stdin") == 0
-			|| file.compare("STDIN") == 0) {
-		if (verbose) {
-			cout << "Reading input from stdin " << endl;
-		}
-		toplevel = readSect(cin);
-	} else {
-		const char *fname = file.data();
-		if (verbose)
-			cout << "Opening input file, '" << file << "'" << endl;
-		ifstream fis(fname);
-		if (not fis) {
-			THROW_GETKW("Open failed: " + file);
-		}
-		toplevel = readSect(fis);
-	}
-	cur = toplevel;
-
+  toplevel = 0;
+  if (file.empty() != 0 || file.compare("stdin") == 0 ||
+      file.compare("STDIN") == 0) {
+    if (verbose) {
+      cout << "Reading input from stdin " << endl;
+    }
+    toplevel = readSect(cin);
+  } else {
+    const char * fname = file.data();
+    if (verbose)
+      cout << "Opening input file, '" << file << "'" << endl;
+    ifstream fis(fname);
+    if (not fis) {
+      THROW_GETKW("Open failed: " + file);
+    }
+    toplevel = readSect(fis);
+  }
+  cur = toplevel;
 }
 
 Getkw::Getkw() {
-	verbose = false;
-	strict = false;
-	toplevel = 0;
-	cur = 0;
+  verbose = false;
+  strict = false;
+  toplevel = 0;
+  cur = 0;
 }
 
-Getkw::Getkw(const Getkw &kw) {
-	verbose = kw.verbose;
-	strict = kw.strict;
-	file = kw.file;
-	*toplevel = *kw.toplevel;
-	cur = toplevel;
+Getkw::Getkw(const Getkw & kw) {
+  verbose = kw.verbose;
+  strict = kw.strict;
+  file = kw.file;
+  *toplevel = *kw.toplevel;
+  cur = toplevel;
 }
 
-Getkw &Getkw::operator=(const Getkw &kw) {
-	if (&kw == this) {
-		return *this;
-	}
-	verbose = kw.verbose;
-	strict = kw.strict;
-	file = kw.file;
-	if (toplevel == 0) {
-		toplevel = new Section(*kw.toplevel);
-	} else {
-		*toplevel = *kw.toplevel;
-	}
-	cur = toplevel;
-	sstack = stack<const Section *>();
-	return *this;
+Getkw & Getkw::operator=(const Getkw & kw) {
+  if (&kw == this) {
+    return *this;
+  }
+  verbose = kw.verbose;
+  strict = kw.strict;
+  file = kw.file;
+  if (toplevel == 0) {
+    toplevel = new Section(*kw.toplevel);
+  } else {
+    *toplevel = *kw.toplevel;
+  }
+  cur = toplevel;
+  sstack = stack<const Section *>();
+  return *this;
 }
 
-Getkw::~Getkw() {
-	delete toplevel;
+Getkw::~Getkw() { delete toplevel; }
+
+void Getkw::setStrict(bool flag) { strict = flag; }
+
+void Getkw::setVerbose(bool flag) { verbose = flag; }
+
+void Getkw::print() const { cout << &repr(cout) << endl; }
+
+ostream & Getkw::repr(ostream & o) const {
+  if (toplevel == 0) {
+    o << "Getkw not yet initialized" << endl;
+  } else {
+    o << *toplevel;
+  }
+  return o;
 }
 
-void Getkw::setStrict(bool flag) {
-	strict = flag;
+template <class T> const T & Getkw::get(const string & path) const {
+  if (cur == 0) {
+    THROW_GETKW("Getkw has not been initialized!");
+  }
+  const Keyword<T> & key = cur->getKey<T>(path);
+  return key.get();
 }
 
-void Getkw::setVerbose(bool flag) {
-	verbose = flag;
+template <class T> const Keyword<T> & Getkw::getKeyword(const string & path) const {
+  if (cur == 0) {
+    THROW_GETKW("Getkw has not been initialized!");
+  }
+  return cur->getKey<T>(path);
 }
 
-void Getkw::print() const
-{
-	cout << &repr(cout) << endl;
+const Section & Getkw::getSect(const string & path) const {
+  if (cur == 0) {
+    THROW_GETKW("Getkw has not been initialized!");
+  }
+  return cur->getSect(path);
 }
 
-ostream &Getkw::repr(ostream &o) const
-{
-	if (toplevel == 0) {
-		o << "Getkw not yet initialized" << endl;
-	} else {
-		o << *toplevel;
-	}
-	return o;
-}
-
-template<class T>
-const T &Getkw::get(const string &path) const {
-	if (cur == 0) {
-		THROW_GETKW("Getkw has not been initialized!");
-	}
-	const Keyword<T> &key = cur->getKey<T>(path);
-	return key.get();
-}
-
-template<class T>
-const Keyword<T> &Getkw::getKeyword(const string &path) const {
-	if (cur == 0) {
-		THROW_GETKW("Getkw has not been initialized!");
-	}
-	return cur->getKey<T>(path);
-}
-
-const Section &Getkw::getSect(const string &path) const {
-	if (cur == 0) {
-		THROW_GETKW("Getkw has not been initialized!");
-	}
-	return cur->getSect(path);
-}
-
-void Getkw::pushSection(const string &path) {
-	if (cur == 0) {
-		THROW_GETKW("Getkw has not been initialized!");
-	}
-	sstack.push(cur);
-	try {
-		const Section &newsec = cur->getSect(path);
-		cur = &newsec;
-	} catch (string err) {
-		cout << err;
-		if (strict)
-			exit(1);
-	}
+void Getkw::pushSection(const string & path) {
+  if (cur == 0) {
+    THROW_GETKW("Getkw has not been initialized!");
+  }
+  sstack.push(cur);
+  try {
+    const Section & newsec = cur->getSect(path);
+    cur = &newsec;
+  } catch (string err) {
+    cout << err;
+    if (strict)
+      exit(1);
+  }
 }
 
 void Getkw::popSection() {
-	if (sstack.empty()) {
-		cout << "Error! Getkw stack is empty!" << endl;
-		if (strict)
-			exit(1);
-	}
-	cur = sstack.top();
-	sstack.pop();
+  if (sstack.empty()) {
+    cout << "Error! Getkw stack is empty!" << endl;
+    if (strict)
+      exit(1);
+  }
+  cur = sstack.top();
+  sstack.pop();
 }
 
-Section *Getkw::readSect(istream &fis) {
-	istringstream isi;
-	string name;
-	string tag;
-	string dum1, dum2;
-	string set;
-	int nsect, nkeys, i;
-	bool isSet, hasTag;
+Section * Getkw::readSect(istream & fis) {
+  istringstream isi;
+  string name;
+  string tag;
+  string dum1, dum2;
+  string set;
+  int nsect, nkeys, i;
+  bool isSet, hasTag;
 
-	readline(fis, isi);
-	isi >> dum1 >> name >> nsect >> set;
-	readline(fis, isi);
-	isi >> dum1 >> tag >> dum2 >> nkeys;
+  readline(fis, isi);
+  isi >> dum1 >> name >> nsect >> set;
+  readline(fis, isi);
+  isi >> dum1 >> tag >> dum2 >> nkeys;
 
-	isSet = convBool(set);
-	hasTag = convBool(tag);
+  isSet = convBool(set);
+  hasTag = convBool(tag);
 
-	Section *thissect = new Section(name);
-	thissect->setDefined(isSet);
-	if (hasTag) {
-		readline(fis, isi);
-		isi >> tag;
-		thissect->setTag(tag);
-	} else {
-		thissect->setTag(name);
-	}
+  Section * thissect = new Section(name);
+  thissect->setDefined(isSet);
+  if (hasTag) {
+    readline(fis, isi);
+    isi >> tag;
+    thissect->setTag(tag);
+  } else {
+    thissect->setTag(name);
+  }
 
-	for (i = 0; i < nkeys; i++) {
-		readKey(thissect, fis);
-	}
-	for (i = 0; i < nsect; i++) {
-		Section *newsect = readSect(fis);
-		thissect->addSect(newsect);
-	}
-	return thissect;
+  for (i = 0; i < nkeys; i++) {
+    readKey(thissect, fis);
+  }
+  for (i = 0; i < nsect; i++) {
+    Section * newsect = readSect(fis);
+    thissect->addSect(newsect);
+  }
+  return thissect;
 }
 
-bool Getkw::readKey(Section *sect, istream &fis) {
-	istringstream isi;
-	string type, name, set;
-	int len;
+bool Getkw::readKey(Section * sect, istream & fis) {
+  istringstream isi;
+  string type, name, set;
+  int len;
 
-	readline(fis, isi);
-	isi >> type >> name >> len >> set;
+  readline(fis, isi);
+  isi >> type >> name >> len >> set;
 
-	bool setf = convBool(set);
-	int kind = convKind(type);
+  bool setf = convBool(set);
+  int kind = convKind(type);
 
-	string ss;
-	vector<int> iv;
-	vector<double> dv;
-	vector<bool> bv;
-	vector<string> sv;
+  string ss;
+  vector<int> iv;
+  vector<double> dv;
+  vector<bool> bv;
+  vector<string> sv;
 
-	switch (kind) {
-	case KeyType::Int:
-		TEST_ARRAY;
-		if (len == 0)
-			return false;
-		int is;
-		readline(fis, isi);
-		isi >> is;
-		sect->addKey(new Keyword<int> (name, is, setf));
-		break;
-	case KeyType::Dbl:
-		TEST_ARRAY;
-		if (len == 0)
-			return false;
-		double ds;
-		readline(fis, isi);
-		isi >> ds;
-		sect->addKey(new Keyword<double> (name, ds, setf));
-		break;
-	case KeyType::Bool:
-		TEST_ARRAY;
-		if (len == 0)
-			return false;
-		bool bs;
-		readline(fis, isi);
-		isi >> ss;
-		bs = convBool(ss);
-		sect->addKey(new Keyword<bool> (name, bs, setf));
-		break;
-	case KeyType::Str:
-		TEST_ARRAY;
-		if (len == 0)
-			return false;
-		getline(fis, ss);
-		sect->addKey(new Keyword<string> (name, ss, setf));
-		break;
-	case KeyType::IntArray:
-		if (len == 0)
-			return false;
-		int ival;
-		for (int i = 0; i < len; i++) {
-			readline(fis, isi);
-			isi >> ival;
-			iv.push_back(ival);
-		}
-		sect->addKey(new Keyword<vector<int> >(name, iv, setf));
-		break;
-	case KeyType::DblArray:
-		if (len == 0)
-			return false;
-		double dval;
-		for (int i = 0; i < len; i++) {
-			readline(fis, isi);
-			isi >> dval;
-			dv.push_back(dval);
-		}
-		sect->addKey(new Keyword<vector<double> >(name, dv, setf));
-		break;
-	case KeyType::BoolArray:
-		if (len == 0)
-			return false;
-		bool bval;
-		for (int i = 0; i < len; i++) {
-			readline(fis, isi);
-			isi >> ss;
-			bval = convBool(ss);
-			bv.push_back(bval);
-		}
-		sect->addKey(new Keyword<vector<bool> >(name, bv, setf));
-		break;
-	case KeyType::StrArray:
-	case KeyType::Data:
-		if (len == 0)
-			return false;
-		for (int i = 0; i < len; i++) {
-			getline(fis, ss);
-			sv.push_back(ss);
-		}
-		sect->addKey(new Keyword<vector<string> >(name, sv, setf));
-		break;
-	default:
-		THROW_GETKW("Unknown keyword type: " + name + " <> " + type);
-	}
-	return true;
-
+  switch (kind) {
+    case KeyType::Int:
+      TEST_ARRAY;
+      if (len == 0)
+        return false;
+      int is;
+      readline(fis, isi);
+      isi >> is;
+      sect->addKey(new Keyword<int>(name, is, setf));
+      break;
+    case KeyType::Dbl:
+      TEST_ARRAY;
+      if (len == 0)
+        return false;
+      double ds;
+      readline(fis, isi);
+      isi >> ds;
+      sect->addKey(new Keyword<double>(name, ds, setf));
+      break;
+    case KeyType::Bool:
+      TEST_ARRAY;
+      if (len == 0)
+        return false;
+      bool bs;
+      readline(fis, isi);
+      isi >> ss;
+      bs = convBool(ss);
+      sect->addKey(new Keyword<bool>(name, bs, setf));
+      break;
+    case KeyType::Str:
+      TEST_ARRAY;
+      if (len == 0)
+        return false;
+      getline(fis, ss);
+      sect->addKey(new Keyword<string>(name, ss, setf));
+      break;
+    case KeyType::IntArray:
+      if (len == 0)
+        return false;
+      int ival;
+      for (int i = 0; i < len; i++) {
+        readline(fis, isi);
+        isi >> ival;
+        iv.push_back(ival);
+      }
+      sect->addKey(new Keyword<vector<int> >(name, iv, setf));
+      break;
+    case KeyType::DblArray:
+      if (len == 0)
+        return false;
+      double dval;
+      for (int i = 0; i < len; i++) {
+        readline(fis, isi);
+        isi >> dval;
+        dv.push_back(dval);
+      }
+      sect->addKey(new Keyword<vector<double> >(name, dv, setf));
+      break;
+    case KeyType::BoolArray:
+      if (len == 0)
+        return false;
+      bool bval;
+      for (int i = 0; i < len; i++) {
+        readline(fis, isi);
+        isi >> ss;
+        bval = convBool(ss);
+        bv.push_back(bval);
+      }
+      sect->addKey(new Keyword<vector<bool> >(name, bv, setf));
+      break;
+    case KeyType::StrArray:
+    case KeyType::Data:
+      if (len == 0)
+        return false;
+      for (int i = 0; i < len; i++) {
+        getline(fis, ss);
+        sv.push_back(ss);
+      }
+      sect->addKey(new Keyword<vector<string> >(name, sv, setf));
+      break;
+    default:
+      THROW_GETKW("Unknown keyword type: " + name + " <> " + type);
+  }
+  return true;
 }
 
-void Getkw::readline(istream &fis, istringstream &isi) {
-	static string buf;
-	getline(fis, buf);
-	isi.clear();
-	isi.str(buf);
+void Getkw::readline(istream & fis, istringstream & isi) {
+  static string buf;
+  getline(fis, buf);
+  isi.clear();
+  isi.str(buf);
 }
 
-bool Getkw::convBool(const string &val) {
-	if (val[0] == 'T' or val[0] == 't')
-		return true;
-	return false;
-
+bool Getkw::convBool(const string & val) {
+  if (val[0] == 'T' or val[0] == 't')
+    return true;
+  return false;
 }
 
-int Getkw::convKind(const string &typ) {
-	static const string INT = "INT";
-	static const string DBL = "DBL";
-	static const string BOOL = "BOOL";
-	static const string STR = "STR";
-	static const string DATA = "DATA";
-	static const string INT_ARRAY = "INT_ARRAY";
-	static const string DBL_ARRAY = "DBL_ARRAY";
-	static const string BOOL_ARRAY = "BOOL_ARRAY";
-	static const string STR_ARRAY = "STR_ARRAY";
+int Getkw::convKind(const string & typ) {
+  static const string INT = "INT";
+  static const string DBL = "DBL";
+  static const string BOOL = "BOOL";
+  static const string STR = "STR";
+  static const string DATA = "DATA";
+  static const string INT_ARRAY = "INT_ARRAY";
+  static const string DBL_ARRAY = "DBL_ARRAY";
+  static const string BOOL_ARRAY = "BOOL_ARRAY";
+  static const string STR_ARRAY = "STR_ARRAY";
 
-	if (typ.compare(INT) == 0)
-		return KeyType::Int;
-	if (typ.compare(DBL) == 0)
-		return KeyType::Dbl;
-	if (typ.compare(BOOL) == 0)
-		return KeyType::Bool;
-	if (typ.compare(STR) == 0)
-		return KeyType::Str;
-	if (typ.compare(DATA) == 0)
-		return KeyType::Data;
-	if (typ.compare(INT_ARRAY) == 0)
-		return KeyType::IntArray;
-	if (typ.compare(DBL_ARRAY) == 0)
-		return KeyType::DblArray;
-	if (typ.compare(BOOL_ARRAY) == 0)
-		return KeyType::BoolArray;
-	if (typ.compare(STR_ARRAY) == 0)
-		return KeyType::StrArray;
-	return -1;
+  if (typ.compare(INT) == 0)
+    return KeyType::Int;
+  if (typ.compare(DBL) == 0)
+    return KeyType::Dbl;
+  if (typ.compare(BOOL) == 0)
+    return KeyType::Bool;
+  if (typ.compare(STR) == 0)
+    return KeyType::Str;
+  if (typ.compare(DATA) == 0)
+    return KeyType::Data;
+  if (typ.compare(INT_ARRAY) == 0)
+    return KeyType::IntArray;
+  if (typ.compare(DBL_ARRAY) == 0)
+    return KeyType::DblArray;
+  if (typ.compare(BOOL_ARRAY) == 0)
+    return KeyType::BoolArray;
+  if (typ.compare(STR_ARRAY) == 0)
+    return KeyType::StrArray;
+  return -1;
 }
 
-template const int &Getkw::get<int>(const string&) const;
-template const bool &Getkw::get<bool>(const string&) const;
-template const double &Getkw::get<double>(const string&) const;
-template const string &Getkw::get<string>(const string&) const;
-template const vector<int> &Getkw::get<vector<int> >(const string&) const;
-template const vector<double> &Getkw::get<vector<double> >(const string&) const;
-template const vector<bool> &Getkw::get<vector<bool> >(const string&) const;
-template const vector<string> &Getkw::get<vector<string> >(const string&) const;
+template const int & Getkw::get<int>(const string &) const;
+template const bool & Getkw::get<bool>(const string &) const;
+template const double & Getkw::get<double>(const string &) const;
+template const string & Getkw::get<string>(const string &) const;
+template const vector<int> & Getkw::get<vector<int> >(const string &) const;
+template const vector<double> & Getkw::get<vector<double> >(const string &) const;
+template const vector<bool> & Getkw::get<vector<bool> >(const string &) const;
+template const vector<string> & Getkw::get<vector<string> >(const string &) const;

--- a/src/utils/getkw/Getkw.h
+++ b/src/utils/getkw/Getkw.h
@@ -10,72 +10,73 @@
 #ifndef GETKW_H_
 #define GETKW_H_
 
-#include <iostream>
+#include <boost/any.hpp>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 #include <stack>
-#include <boost/any.hpp>
 
-#include "Section.h"
-#include "Keyword.h"
 #include "GetkwError.h"
+#include "Keyword.h"
+#include "Section.h"
 
 class Getkw {
 public:
-	Getkw(std::string file, bool _verbose = false, bool _strict = false);
-	Getkw(const Getkw &kw);
-	Getkw &operator=(const Getkw &kw);
-	Getkw();
-	virtual ~Getkw();
-	void setStrict(bool flag);
-	void setVerbose(bool flag);
-	void pushSection(const std::string &path);
-	void popSection();
-	const Section &getSect(const std::string &path) const;
-	template<class T> const Keyword<T> 
-        &getKeyword(const std::string &path) const;
-	template<class T> const T &get(const std::string &path) const;
+  Getkw(std::string file, bool _verbose = false, bool _strict = false);
+  Getkw(const Getkw & kw);
+  Getkw & operator=(const Getkw & kw);
+  Getkw();
+  virtual ~Getkw();
+  void setStrict(bool flag);
+  void setVerbose(bool flag);
+  void pushSection(const std::string & path);
+  void popSection();
+  const Section & getSect(const std::string & path) const;
+  template <class T> const Keyword<T> & getKeyword(const std::string & path) const;
+  template <class T> const T & get(const std::string & path) const;
 
-	int getInt(const std::string &path) const {return get<int>(path);}
-	double getDbl(const std::string &path) const {return get<double>(path);}
-	bool getBool(const std::string &path) const {return get<bool>(path);}
-	const std::string &getStr(const std::string &path) const {
-        return get<std::string>(path);
-    }
-	const std::vector<int> getIntVec(const std::string &path) const {
-		return get<std::vector<int> >(path);
-	}
-	const std::vector<double> getDblVec(const std::string &path) const {
-		return get<std::vector<double> >(path);
-	}
-	const std::vector<bool> getBoolVec(const std::string &path) const {
-		return get<std::vector<bool> >(path);
-	}
-	const std::vector<std::string> getStrVec(const std::string &path) const {
-		return get<std::vector<std::string> >(path);
-	}
-	const std::vector<std::string> getData(const std::string &path) const {
-		return getStrVec(path);
-	}
+  int getInt(const std::string & path) const { return get<int>(path); }
+  double getDbl(const std::string & path) const { return get<double>(path); }
+  bool getBool(const std::string & path) const { return get<bool>(path); }
+  const std::string & getStr(const std::string & path) const {
+    return get<std::string>(path);
+  }
+  const std::vector<int> getIntVec(const std::string & path) const {
+    return get<std::vector<int> >(path);
+  }
+  const std::vector<double> getDblVec(const std::string & path) const {
+    return get<std::vector<double> >(path);
+  }
+  const std::vector<bool> getBoolVec(const std::string & path) const {
+    return get<std::vector<bool> >(path);
+  }
+  const std::vector<std::string> getStrVec(const std::string & path) const {
+    return get<std::vector<std::string> >(path);
+  }
+  const std::vector<std::string> getData(const std::string & path) const {
+    return getStrVec(path);
+  }
 
-	void print() const;
-	std::ostream &repr(std::ostream &o) const;
-	friend std::ostream &operator<<(std::ostream &o, const Getkw &gkw) {
-		return gkw.repr(o);
-	}
+  void print() const;
+  std::ostream & repr(std::ostream & o) const;
+  friend std::ostream & operator<<(std::ostream & o, const Getkw & gkw) {
+    return gkw.repr(o);
+  }
+
 protected:
-	static Section *readSect(std::istream &fis);
-	static bool readKey(Section *sect, std::istream &fis);
-	static void readline(std::istream &fis, std::istringstream &isi);
-	static bool convBool(const std::string &val);
-	static int convKind(const std::string &typ);
+  static Section * readSect(std::istream & fis);
+  static bool readKey(Section * sect, std::istream & fis);
+  static void readline(std::istream & fis, std::istringstream & isi);
+  static bool convBool(const std::string & val);
+  static int convKind(const std::string & typ);
+
 private:
-	bool verbose;
-	bool strict;
-	std::string file;
-	Section *toplevel;
-	const Section *cur;
-	std::stack<const Section *> sstack;
+  bool verbose;
+  bool strict;
+  std::string file;
+  Section * toplevel;
+  const Section * cur;
+  std::stack<const Section *> sstack;
 };
 
 #endif /* GETKW_H_ */

--- a/src/utils/getkw/GetkwError.cpp
+++ b/src/utils/getkw/GetkwError.cpp
@@ -13,53 +13,44 @@
 bool GetkwError::strict = false;
 bool GetkwError::verbose = true;
 
-GetkwError::GetkwError() {
+GetkwError::GetkwError() {}
+
+GetkwError::GetkwError(const string & err) : msg(err) {
+  if (verbose or strict) {
+    cout << "Error: " << msg << endl;
+  }
+  if (strict) {
+    cout << "Exiting..." << endl;
+    exit(1);
+  }
 }
 
-GetkwError::GetkwError(const string &err):
-	msg(err) {
-	if (verbose or strict) {
-		cout << "Error: " << msg << endl;
-	}
-	if (strict) {
-		cout << "Exiting..." << endl;
-		exit(1);
-	}
-}
-
-GetkwError::GetkwError(ostringstream &err) {
-	this->msg = err.str();
-	if (verbose or strict) {
-		cout << "Error: " << msg << endl;
-	}
-	if (strict) {
-		cout << "Exiting..." << endl;
-		exit(1);
-	}
+GetkwError::GetkwError(ostringstream & err) {
+  this->msg = err.str();
+  if (verbose or strict) {
+    cout << "Error: " << msg << endl;
+  }
+  if (strict) {
+    cout << "Exiting..." << endl;
+    exit(1);
+  }
 }
 GetkwError::~GetkwError() throw() {
-	// TODO Auto-generated destructor stub
+  // TODO Auto-generated destructor stub
 }
 
-void GetkwError::trigger(const string &err)
-{
-	msg = err;
-	if (verbose or strict) {
-		cout << "Error: " << msg << endl;
-	}
-	if (strict) {
-		cout << "Exiting..." << endl;
-		exit(1);
-	}
-	throw *this;
+void GetkwError::trigger(const string & err) {
+  msg = err;
+  if (verbose or strict) {
+    cout << "Error: " << msg << endl;
+  }
+  if (strict) {
+    cout << "Exiting..." << endl;
+    exit(1);
+  }
+  throw * this;
 }
 
-void GetkwError::setVerbose(bool flag)
-{
-	verbose = flag;
-}
+void GetkwError::setVerbose(bool flag) { verbose = flag; }
 
-void GetkwError::setStrict(bool flag)
-{
-	strict = flag;
-}
+void GetkwError::setStrict(bool flag) { strict = flag; }

--- a/src/utils/getkw/GetkwError.h
+++ b/src/utils/getkw/GetkwError.h
@@ -17,34 +17,37 @@
 #include <sstream>
 #include <string>
 
-//TODO: define ABORT_EXCEPTION and redefine THROW not to throw, but abort.
+// TODO: define ABORT_EXCEPTION and redefine THROW not to throw, but abort.
 
-#define THROW_GETKW(X) {std::ostringstream _err; \
-	_err << "Error: " << __func__ << ",  line " << __LINE__ << \
-	" in  " << __FILE__ << ": " << X << endl;\
-	throw GetkwError(_err); }
+#define THROW_GETKW(X)                                                              \
+  {                                                                                 \
+    std::ostringstream _err;                                                        \
+    _err << "Error: " << __func__ << ",  line " << __LINE__ << " in  " << __FILE__  \
+         << ": " << X << endl;                                                      \
+    throw GetkwError(_err);                                                         \
+  }
 
 using namespace std;
 
-class GetkwError: public exception {
+class GetkwError : public exception {
 public:
-	GetkwError();
-	GetkwError(const string &err);
-	GetkwError(ostringstream &err);
-	virtual ~GetkwError() throw();
-	void trigger(const string &msg);
-	static void setVerbose(bool flag);
-	static void setStrict(bool flag);
-	friend ostream& operator<<(ostream &o, const GetkwError &e) {
-			return o << e.msg;
-	}
-//	virtual const char *what() {
-//		return err.c_str();
-//	}
+  GetkwError();
+  GetkwError(const string & err);
+  GetkwError(ostringstream & err);
+  virtual ~GetkwError() throw();
+  void trigger(const string & msg);
+  static void setVerbose(bool flag);
+  static void setStrict(bool flag);
+  friend ostream & operator<<(ostream & o, const GetkwError & e) {
+    return o << e.msg;
+  }
+  //	virtual const char *what() {
+  //		return err.c_str();
+  //	}
 private:
-	string msg;
-	static bool verbose;
-	static bool strict;
+  string msg;
+  static bool verbose;
+  static bool strict;
 };
 
 #endif /* GETKWERROR_H_ */

--- a/src/utils/getkw/Keyword.h
+++ b/src/utils/getkw/Keyword.h
@@ -10,195 +10,174 @@
 #ifndef KEYWORD_H_
 #define KEYWORD_H_
 
+#include <fstream>
 #include <string>
 #include <vector>
-#include <fstream>
 
 #include "GetkwError.h"
 
 namespace KeyType {
-	enum KeyKinds {
-		Unknown = -1,
-		Undefined,
-		Int,
-		Dbl,
-		Bool,
-		Str,
-		IntArray,
-		DblArray,
-		BoolArray,
-		StrArray,
-		Data
-	};
+enum KeyKinds {
+  Unknown = -1,
+  Undefined,
+  Int,
+  Dbl,
+  Bool,
+  Str,
+  IntArray,
+  DblArray,
+  BoolArray,
+  StrArray,
+  Data
+};
 };
 
-
-template <class T>
-class Keyword {
+template <class T> class Keyword {
 public:
-	Keyword(const std::string _name, const T &_val, bool _isDefd = false):
-			name(_name), val(_val), isDefd(_isDefd) {
-		if (not setKind(_val)) {
-			THROW_GETKW("Invalid key type!");
-		}
-	}
+  Keyword(const std::string _name, const T & _val, bool _isDefd = false)
+      : name(_name), val(_val), isDefd(_isDefd) {
+    if (not setKind(_val)) {
+      THROW_GETKW("Invalid key type!");
+    }
+  }
 
-	virtual ~Keyword() {
-	}
+  virtual ~Keyword() {}
 
-	const T &get() const {
-		return val;
-	}
-	void set(T &t) {
-		val = t;
-	}
+  const T & get() const { return val; }
+  void set(T & t) { val = t; }
 
-	bool isDefined() const {
-		return isDefd;
-	}
+  bool isDefined() const { return isDefd; }
 
-	const std::string &getName() const {
-		return name;
-	}
+  const std::string & getName() const { return name; }
 
-	int getKind() const {
-		return kind;
-	}
-	void setDefined(bool _isDefd) {
-		isDefd = _isDefd;
-	}
+  int getKind() const { return kind; }
+  void setDefined(bool _isDefd) { isDefd = _isDefd; }
 
-	void setName(const std::string &_name) {
-		name = _name;
-	}
+  void setName(const std::string & _name) { name = _name; }
 
+  template <typename X> std::ostream & repr(std::ostream & o, X /* v */) const {
+    if (kind == KeyType::Str) {
+      o << "  " + name << " = "
+        << "\"" << val << "\"";
+    } else {
+      o << "  " + name << " = " << val;
+    }
+    return o;
+  }
+  template <typename X>
+  std::ostream & repr(std::ostream & o, const std::vector<X> & v) const {
+    o << "  " << name << " = [ ";
+    if (kind == KeyType::StrArray) {
+      o << std::endl;
+      o << "\"" << v[0] << "\"";
+    } else {
+      o << val[0];
+    }
 
-	template <typename X>
-	std::ostream &repr(std::ostream &o, X /* v */) const {
-		if (kind == KeyType::Str) {
-			o << "  " + name << " = " << "\"" << val << "\"";
-		} else {
-			o << "  " + name << " = " << val;
-		}
-		return o;
-	}
-	template <typename X>
-			std::ostream &repr(std::ostream &o, const std::vector<X> &v) const {
-		o << "  " << name << " = [ ";
-		if (kind == KeyType::StrArray) {
-			o << std::endl;
-			o << "\"" << v[0] << "\"";
-		} else {
-			o << val[0];
-		}
+    for (unsigned int i = 1; i < val.size(); i++) {
+      if (kind == KeyType::StrArray) {
+        o << ", " << std::endl << "\"" << v[i] << "\"";
+      } else {
+        o << ", " << v[i];
+      }
+    }
+    o << " ]";
+    return o;
+  }
+  friend std::ostream & operator<<(std::ostream & o, const Keyword<T> & key) {
+    return key.repr(o, key.get());
+  }
 
-		for (unsigned int i = 1; i < val.size(); i++) {
-			if (kind == KeyType::StrArray) {
-				o << ", " << std::endl << "\"" << v[i] << "\"";
-			} else {
-				o << ", " << v[i];
-			}
-		}
-		o << " ]";
-		return o;
-	}
-	friend std::ostream& operator <<(std::ostream& o, const Keyword<T> &key) {
-		return key.repr(o, key.get());
-	}
+  virtual void print() const { std::cout << &repr(std::cout, val) << std::endl; }
 
-	virtual void print() const {
-		std::cout << &repr(std::cout, val) << std::endl;
-	}
+  static const std::string & getNamedKind(int i) {
+    static const std::string INT = "Int";
+    static const std::string DBL = "Dbl";
+    static const std::string BOOL = "Bool";
+    static const std::string STR = "Str";
+    static const std::string INT_ARRAY = "IntArray";
+    static const std::string DBL_ARRAY = "DblArray";
+    static const std::string BOOL_ARRAY = "BoolArray";
+    static const std::string STR_ARRAY = "StrArray";
+    static const std::string UNDEF = "Undefined";
+    static const std::string UNKN = "Unknown";
 
+    switch (i) {
+      case (KeyType::Int):
+        return INT;
+      case (KeyType::Dbl):
+        return DBL;
+      case (KeyType::Bool):
+        return BOOL;
+      case (KeyType::Str):
+        return STR;
+      case (KeyType::IntArray):
+        return INT_ARRAY;
+      case (KeyType::DblArray):
+        return DBL_ARRAY;
+      case (KeyType::BoolArray):
+        return BOOL_ARRAY;
+      case (KeyType::StrArray):
+        return STR_ARRAY;
+      case (KeyType::Undefined):
+        return UNDEF;
+    }
+    return UNKN;
+  }
 
-	static const std::string &getNamedKind(int i) {
-		static const std::string INT = "Int";
-		static const std::string DBL = "Dbl";
-		static const std::string BOOL = "Bool";
-		static const std::string STR = "Str";
-		static const std::string INT_ARRAY = "IntArray";
-		static const std::string DBL_ARRAY = "DblArray";
-		static const std::string BOOL_ARRAY = "BoolArray";
-		static const std::string STR_ARRAY = "StrArray";
-		static const std::string UNDEF = "Undefined";
-		static const std::string UNKN = "Unknown";
-
-		switch (i) {
-		case (KeyType::Int):
-			return INT;
-		case (KeyType::Dbl):
-			return DBL;
-		case (KeyType::Bool):
-			return BOOL;
-		case (KeyType::Str):
-			return STR;
-		case (KeyType::IntArray):
-			return INT_ARRAY;
-		case (KeyType::DblArray):
-			return DBL_ARRAY;
-		case (KeyType::BoolArray):
-			return BOOL_ARRAY;
-		case (KeyType::StrArray):
-			return STR_ARRAY;
-		case (KeyType::Undefined):
-			return UNDEF;
-		}
-		return UNKN;
-	}
 protected:
-	std::string name;
-	T val;
-	bool isDefd;
-	bool isArray;
-	int kind;
+  std::string name;
+  T val;
+  bool isDefd;
+  bool isArray;
+  int kind;
 
-	bool setKind(int /* t */) {
-		isArray = false;
-		kind = KeyType::Int;
-		return true;
-	}
-	bool setKind(double /* t */) {
-		isArray = false;
-		kind = KeyType::Dbl;
-		return true;
-	}
-	bool setKind(bool /* t */) {
-		isArray = false;
-		kind = KeyType::Bool;
-		return true;
-	}
-	bool setKind(const std::string & /* t */) {
-		isArray = false;
-		kind = KeyType::Str;
-		return true;
-	}
+  bool setKind(int /* t */) {
+    isArray = false;
+    kind = KeyType::Int;
+    return true;
+  }
+  bool setKind(double /* t */) {
+    isArray = false;
+    kind = KeyType::Dbl;
+    return true;
+  }
+  bool setKind(bool /* t */) {
+    isArray = false;
+    kind = KeyType::Bool;
+    return true;
+  }
+  bool setKind(const std::string & /* t */) {
+    isArray = false;
+    kind = KeyType::Str;
+    return true;
+  }
 
-	bool setKind(const std::vector<int> & /* t */) {
-		isArray = true;
-		kind = KeyType::IntArray;
-		return true;
-	}
-	bool setKind(const std::vector<double> & /* t */) {
-		isArray = true;
-		kind = KeyType::DblArray;
-		return true;
-	}
-	bool setKind(const std::vector<bool> & /* t */) {
-		isArray = true;
-		kind = KeyType::BoolArray;
-		return true;
-	}
-	bool setKind(const std::vector<std::string> & /* t */) {
-		isArray = true;
-		kind = KeyType::StrArray;
-		return true;
-	}
-	template<class X> bool setKind(const X &t) {
-		std::cout << "Warning! Unknown kind:" << t << std::endl;
-		kind = KeyType::Unknown;
-		return false;
-	}
-
+  bool setKind(const std::vector<int> & /* t */) {
+    isArray = true;
+    kind = KeyType::IntArray;
+    return true;
+  }
+  bool setKind(const std::vector<double> & /* t */) {
+    isArray = true;
+    kind = KeyType::DblArray;
+    return true;
+  }
+  bool setKind(const std::vector<bool> & /* t */) {
+    isArray = true;
+    kind = KeyType::BoolArray;
+    return true;
+  }
+  bool setKind(const std::vector<std::string> & /* t */) {
+    isArray = true;
+    kind = KeyType::StrArray;
+    return true;
+  }
+  template <class X> bool setKind(const X & t) {
+    std::cout << "Warning! Unknown kind:" << t << std::endl;
+    kind = KeyType::Unknown;
+    return false;
+  }
 };
 
 #endif /* KEYWORD_H_ */

--- a/src/utils/getkw/Section.cpp
+++ b/src/utils/getkw/Section.cpp
@@ -9,381 +9,374 @@
 
 #include <iostream>
 
-#include "Section.h"
 #include "GetkwError.h"
+#include "Section.h"
 
-#define IF_ANY_KEYTYPE_IS(A, T) \
-if (A.type() == typeid(const Keyword< T > *))
+#define IF_ANY_KEYTYPE_IS(A, T) if (A.type() == typeid(const Keyword<T> *))
 
-#define ANY_TO_CONST_KEY_PTR(A, T) \
-boost::any_cast<const Keyword< T > *>(A)
+#define ANY_TO_CONST_KEY_PTR(A, T) boost::any_cast<const Keyword<T> *>(A)
 
 #define PRINT_FUNC_NAME std::cout << "@ Section::" << __func__ << std::endl;
 
 using namespace std;
 
-Section::Section(const string &_name, const string &_tag) :
-	name(_name) {
-	isDefd = false;
-	nsect = 0;
-	nkeys = 0;
-	if (tag.empty()) {
-		this->tag = _name;
-	} else {
-		this->tag = _tag;
-	}
+Section::Section(const string & _name, const string & _tag) : name(_name) {
+  isDefd = false;
+  nsect = 0;
+  nkeys = 0;
+  if (tag.empty()) {
+    this->tag = _name;
+  } else {
+    this->tag = _tag;
+  }
 }
 
-Section::Section(const Section &s) {
-	tag = s.tag;
-	nkeys = s.nkeys;
-	nsect = s.nsect;
+Section::Section(const Section & s) {
+  tag = s.tag;
+  nkeys = s.nkeys;
+  nsect = s.nsect;
 
-	copySects(s);
-	copyKeys(s);
+  copySects(s);
+  copyKeys(s);
 }
 
-Section &Section::operator=(const Section &s) {
-	if (&s == this) {
-		return *this;
-	}
-	name = s.name;
-	tag = s.tag;
-	nkeys = s.nkeys;
-	nsect = s.nsect;
+Section & Section::operator=(const Section & s) {
+  if (&s == this) {
+    return *this;
+  }
+  name = s.name;
+  tag = s.tag;
+  nkeys = s.nkeys;
+  nsect = s.nsect;
 
-	copySects(s);
-	copyKeys(s);
+  copySects(s);
+  copyKeys(s);
 
-	return *this;
+  return *this;
 }
 
 Section::~Section() {
-	map<string, Section *>::iterator sit;
-	map<string, boost::any>::iterator kit;
-	for (sit = sects.begin(); sit != sects.end(); ++sit) {
-		delete sects[sit->first];
-	}
-	for (kit = keys.begin(); kit != keys.end(); ++kit) {
+  map<string, Section *>::iterator sit;
+  map<string, boost::any>::iterator kit;
+  for (sit = sects.begin(); sit != sects.end(); ++sit) {
+    delete sects[sit->first];
+  }
+  for (kit = keys.begin(); kit != keys.end(); ++kit) {
 
-		IF_ANY_KEYTYPE_IS(kit->second, int) {
-			const Keyword<int> *key = ANY_TO_CONST_KEY_PTR(kit->second, int);
-			delete key;
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(kit->second, bool) {
-			const Keyword<bool> *key = ANY_TO_CONST_KEY_PTR(kit->second, bool);
-			delete key;
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(kit->second, double) {
-			const Keyword<double> *key = ANY_TO_CONST_KEY_PTR(kit->second, double);
-			delete key;
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(kit->second, string) {
-			const Keyword<string> *key = ANY_TO_CONST_KEY_PTR(kit->second, string);
-			delete key;
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(kit->second, vector<int>) {
-			const Keyword<vector<int> > *key = ANY_TO_CONST_KEY_PTR(kit->second, vector<int>);
-			delete key;
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(kit->second, vector<bool>) {
-			const Keyword<vector<bool> > *key = ANY_TO_CONST_KEY_PTR(kit->second, vector<bool>);
-			delete key;
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(kit->second, vector<double>) {
-			const Keyword<vector<double> > *key = ANY_TO_CONST_KEY_PTR(kit->second, vector<double>);
-			delete key;
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(kit->second, vector<string>) {
-			const Keyword<vector<string> > *key = ANY_TO_CONST_KEY_PTR(kit->second, vector<string>);
-			delete key;
-			continue;
-		}
-		THROW_GETKW("Error! Unknown key type!");
-	}
+    IF_ANY_KEYTYPE_IS(kit->second, int) {
+      const Keyword<int> * key = ANY_TO_CONST_KEY_PTR(kit->second, int);
+      delete key;
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(kit->second, bool) {
+      const Keyword<bool> * key = ANY_TO_CONST_KEY_PTR(kit->second, bool);
+      delete key;
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(kit->second, double) {
+      const Keyword<double> * key = ANY_TO_CONST_KEY_PTR(kit->second, double);
+      delete key;
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(kit->second, string) {
+      const Keyword<string> * key = ANY_TO_CONST_KEY_PTR(kit->second, string);
+      delete key;
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(kit->second, vector<int>) {
+      const Keyword<vector<int> > * key =
+          ANY_TO_CONST_KEY_PTR(kit->second, vector<int>);
+      delete key;
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(kit->second, vector<bool>) {
+      const Keyword<vector<bool> > * key =
+          ANY_TO_CONST_KEY_PTR(kit->second, vector<bool>);
+      delete key;
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(kit->second, vector<double>) {
+      const Keyword<vector<double> > * key =
+          ANY_TO_CONST_KEY_PTR(kit->second, vector<double>);
+      delete key;
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(kit->second, vector<string>) {
+      const Keyword<vector<string> > * key =
+          ANY_TO_CONST_KEY_PTR(kit->second, vector<string>);
+      delete key;
+      continue;
+    }
+    THROW_GETKW("Error! Unknown key type!");
+  }
 }
 
-void Section::copySects(const Section &s) {
-	map<string, Section *>::const_iterator iter;
-	for (iter = s.sects.begin(); iter != s.sects.end(); ++iter) {
-		sects[iter->first] = new Section(*iter->second);
-		tags[(*iter->second).tag] = sects[iter->first];
-	}
+void Section::copySects(const Section & s) {
+  map<string, Section *>::const_iterator iter;
+  for (iter = s.sects.begin(); iter != s.sects.end(); ++iter) {
+    sects[iter->first] = new Section(*iter->second);
+    tags[(*iter->second).tag] = sects[iter->first];
+  }
 }
 
-void Section::copyKeys(const Section &s) {
-	map<string, boost::any>::const_iterator iter;
+void Section::copyKeys(const Section & s) {
+  map<string, boost::any>::const_iterator iter;
 
-	for (iter = s.keys.begin(); iter != s.keys.end(); ++iter) {
-		IF_ANY_KEYTYPE_IS(iter->second, int) {
-			const Keyword<int> *key = ANY_TO_CONST_KEY_PTR(iter->second, int);
-			keys[iter->first] = boost::any(new const Keyword<int>(*key));
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(iter->second, bool) {
-			const Keyword<bool> *key = ANY_TO_CONST_KEY_PTR(iter->second, bool);
-			keys[iter->first] = boost::any(new const Keyword<bool>(*key));
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(iter->second, double) {
-			const Keyword<double> *key = ANY_TO_CONST_KEY_PTR(iter->second, double);
-			keys[iter->first] = boost::any(new const Keyword<double>(*key));
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(iter->second, string) {
-			const Keyword<string> *key = ANY_TO_CONST_KEY_PTR(iter->second, string);
-			keys[iter->first] = boost::any(new const Keyword<string>(*key));
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(iter->second, vector<int>) {
-			const Keyword<vector<int> > *key = ANY_TO_CONST_KEY_PTR(iter->second, vector<int>);
-			keys[iter->first] = boost::any(new const Keyword<vector<int> >(*key));
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(iter->second, vector<bool>) {
-			const Keyword<vector<bool> > *key = ANY_TO_CONST_KEY_PTR(iter->second, vector<bool>);
-			keys[iter->first] = boost::any(new const Keyword<vector<bool> >(*key));
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(iter->second, vector<double>) {
-			const Keyword<vector<double> > *key = ANY_TO_CONST_KEY_PTR(iter->second, vector<double>);
-			keys[iter->first] = boost::any(new const Keyword<vector<double> >(*key));
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(iter->second, vector<string>) {
-			const Keyword<vector<string> > *key = ANY_TO_CONST_KEY_PTR(iter->second, vector<string>);
-			keys[iter->first] = boost::any(new const Keyword<vector<string> >(*key));
-			continue;
-		}
-		THROW_GETKW("Error! Unknown key type!");
-	}
+  for (iter = s.keys.begin(); iter != s.keys.end(); ++iter) {
+    IF_ANY_KEYTYPE_IS(iter->second, int) {
+      const Keyword<int> * key = ANY_TO_CONST_KEY_PTR(iter->second, int);
+      keys[iter->first] = boost::any(new const Keyword<int>(*key));
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(iter->second, bool) {
+      const Keyword<bool> * key = ANY_TO_CONST_KEY_PTR(iter->second, bool);
+      keys[iter->first] = boost::any(new const Keyword<bool>(*key));
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(iter->second, double) {
+      const Keyword<double> * key = ANY_TO_CONST_KEY_PTR(iter->second, double);
+      keys[iter->first] = boost::any(new const Keyword<double>(*key));
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(iter->second, string) {
+      const Keyword<string> * key = ANY_TO_CONST_KEY_PTR(iter->second, string);
+      keys[iter->first] = boost::any(new const Keyword<string>(*key));
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(iter->second, vector<int>) {
+      const Keyword<vector<int> > * key =
+          ANY_TO_CONST_KEY_PTR(iter->second, vector<int>);
+      keys[iter->first] = boost::any(new const Keyword<vector<int> >(*key));
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(iter->second, vector<bool>) {
+      const Keyword<vector<bool> > * key =
+          ANY_TO_CONST_KEY_PTR(iter->second, vector<bool>);
+      keys[iter->first] = boost::any(new const Keyword<vector<bool> >(*key));
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(iter->second, vector<double>) {
+      const Keyword<vector<double> > * key =
+          ANY_TO_CONST_KEY_PTR(iter->second, vector<double>);
+      keys[iter->first] = boost::any(new const Keyword<vector<double> >(*key));
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(iter->second, vector<string>) {
+      const Keyword<vector<string> > * key =
+          ANY_TO_CONST_KEY_PTR(iter->second, vector<string>);
+      keys[iter->first] = boost::any(new const Keyword<vector<string> >(*key));
+      continue;
+    }
+    THROW_GETKW("Error! Unknown key type!");
+  }
 }
 
-const Section &Section::getSect(const string &pathspec) const {
-	vector<string> path;
-	splitPath(pathspec, path);
-	const Section *sect = traversePath(path, pathspec);
-	return *sect;
+const Section & Section::getSect(const string & pathspec) const {
+  vector<string> path;
+  splitPath(pathspec, path);
+  const Section * sect = traversePath(path, pathspec);
+  return *sect;
 }
 
-template<typename T>
-const Keyword<T> &Section::getKey(const string &pathspec) const {
-	vector<string> path;
-	splitPath(pathspec, path);
+template <typename T>
+const Keyword<T> & Section::getKey(const string & pathspec) const {
+  vector<string> path;
+  splitPath(pathspec, path);
 
-	string name = path.back();
-	const Section *sect = traversePath(path, pathspec);
-	if (!sect->has_key(name)) {
-		THROW_GETKW("Invalid keyword, " + pathspec);
-	}
-	map<string, boost::any>::const_iterator iter = sect->keys.find(name);
-	return *ANY_TO_CONST_KEY_PTR(iter->second, T);
+  string name = path.back();
+  const Section * sect = traversePath(path, pathspec);
+  if (!sect->has_key(name)) {
+    THROW_GETKW("Invalid keyword, " + pathspec);
+  }
+  map<string, boost::any>::const_iterator iter = sect->keys.find(name);
+  return *ANY_TO_CONST_KEY_PTR(iter->second, T);
 }
 
-template<class T>
-const T &Section::get(const string &path) const {
-	const Keyword<T> &key = this->getKey<T>(path);
-	return key.get();
+template <class T> const T & Section::get(const string & path) const {
+  const Keyword<T> & key = this->getKey<T>(path);
+  return key.get();
 }
 
-Section *Section::readSect(ifstream & /* fis */) {
-	return 0;
-}
+Section * Section::readSect(ifstream & /* fis */) { return 0; }
 
 /* Sections can be multiply defined, provided they have different tags.
  * The first section section is added to the box, as well as to the tags
  * map if applicable. The following sections with the same name are added
  * to the tags map.
  */
-void Section::addSect(Section *sect) {
-	string name = sect->name + "<" + sect->tag + ">";
-	if (has_key(name)) {
-		THROW_GETKW("Section::add: Section already defined, " + name);
-	}
+void Section::addSect(Section * sect) {
+  string name = sect->name + "<" + sect->tag + ">";
+  if (has_key(name)) {
+    THROW_GETKW("Section::add: Section already defined, " + name);
+  }
 
-	sects[name] = sect;
-	tags[sect->tag] = sects[name];
-	nsect++;
+  sects[name] = sect;
+  tags[sect->tag] = sects[name];
+  nsect++;
 }
 
-void Section::addSect(Section &sect) {
-	string name = sect.name + "<" + sect.tag + ">";
-	if (has_key(name)) {
-		THROW_GETKW("Section::add: Section already defined, " + name);
-	}
+void Section::addSect(Section & sect) {
+  string name = sect.name + "<" + sect.tag + ">";
+  if (has_key(name)) {
+    THROW_GETKW("Section::add: Section already defined, " + name);
+  }
 
-	sects[name] = new Section(sect);
-	tags[sect.tag] = sects[name];
-	nsect++;
+  sects[name] = new Section(sect);
+  tags[sect.tag] = sects[name];
+  nsect++;
 }
 //! Add an allocated key to a section
-template<class T>
-void Section::addKey(const Keyword<T> *key) {
-	const string &name = key->getName();
+template <class T> void Section::addKey(const Keyword<T> * key) {
+  const string & name = key->getName();
 
-	if (has_key(name)) {
-		THROW_GETKW("Section::add: Key already defined, " + name);
-	}
+  if (has_key(name)) {
+    THROW_GETKW("Section::add: Key already defined, " + name);
+  }
 
-	keys[name] = boost::any(key);
-	nkeys++;
+  keys[name] = boost::any(key);
+  nkeys++;
 }
 
 //! Copy and and add a keyword to a section
-template<class T> void Section::addKey(const Keyword<T> &key) {
-	string name = key.getName();
+template <class T> void Section::addKey(const Keyword<T> & key) {
+  string name = key.getName();
 
-	if (has_key(name)) {
-		THROW_GETKW("Section::add: Key already defined, " + name);
-	}
+  if (has_key(name)) {
+    THROW_GETKW("Section::add: Key already defined, " + name);
+  }
 
-	keys[name] = boost::any(new Keyword<T>(key));
-	nkeys++;
+  keys[name] = boost::any(new Keyword<T>(key));
+  nkeys++;
 }
 
-const Section *Section::traversePath(vector<string> &path,
-									 const string &pathspec) const {
-	string cur = path[0];
+const Section * Section::traversePath(vector<string> & path,
+                                      const string & pathspec) const {
+  string cur = path[0];
 
-	if (path.size() == 1) {
-		if (has_key(cur))
-			return this;
-		if (!has_sect(cur)) {
-			cur = cur + "<" + cur + ">";
-		}
-		if (has_sect(cur)) {
-			map<string, Section *>::const_iterator iter = sects.find(cur);
-			return iter->second;
-		}
-		THROW_GETKW("traversePath: Invalid path, " + pathspec);
-	}
+  if (path.size() == 1) {
+    if (has_key(cur))
+      return this;
+    if (!has_sect(cur)) {
+      cur = cur + "<" + cur + ">";
+    }
+    if (has_sect(cur)) {
+      map<string, Section *>::const_iterator iter = sects.find(cur);
+      return iter->second;
+    }
+    THROW_GETKW("traversePath: Invalid path, " + pathspec);
+  }
 
-	if (!has_sect(cur))
-		cur = cur + "<" + cur + ">";
-	if (!has_sect(cur)) {
-		THROW_GETKW("traversePath: Invalid path, " + pathspec);
-	}
+  if (!has_sect(cur))
+    cur = cur + "<" + cur + ">";
+  if (!has_sect(cur)) {
+    THROW_GETKW("traversePath: Invalid path, " + pathspec);
+  }
 
-	path.erase(path.begin());
-	map<string, Section *>::const_iterator iter = sects.find(cur);
-	return iter->second->traversePath(path, pathspec);
+  path.erase(path.begin());
+  map<string, Section *>::const_iterator iter = sects.find(cur);
+  return iter->second->traversePath(path, pathspec);
 }
 
-void Section::splitPath(const string &pathspec, vector<string> &path) const {
-	string str = pathspec;
-	string::size_type m = 0;
-	while (true) {
-		m = str.find('.', m);
-		if (m == string::npos) {
-			path.push_back(str);
-			break;
-		} else {
-			path.push_back(str.substr(0, m));
-		}
-		m++;
-		str = str.substr(m);
-	}
+void Section::splitPath(const string & pathspec, vector<string> & path) const {
+  string str = pathspec;
+  string::size_type m = 0;
+  while (true) {
+    m = str.find('.', m);
+    if (m == string::npos) {
+      path.push_back(str);
+      break;
+    } else {
+      path.push_back(str.substr(0, m));
+    }
+    m++;
+    str = str.substr(m);
+  }
 }
 
-int Section::splitTag(const string &path, string &tag) const {
-	string::size_type m, n = 0;
-	m = path.find('<');
-	if (m == string::npos)
-		return 0;
-	n = path.find('>');
-	if (n == string::npos or n - m - 1 < 1)
-		return 0;
-	tag.clear();
-	tag.append(path.substr(m + 1, n - m - 1));
-	return m;
+int Section::splitTag(const string & path, string & tag) const {
+  string::size_type m, n = 0;
+  m = path.find('<');
+  if (m == string::npos)
+    return 0;
+  n = path.find('>');
+  if (n == string::npos or n - m - 1 < 1)
+    return 0;
+  tag.clear();
+  tag.append(path.substr(m + 1, n - m - 1));
+  return m;
 }
 
-bool Section::has_key(const string &b) const {
-	if (keys.find(b) == keys.end())
-		return false;
-	return true;
-
+bool Section::has_key(const string & b) const {
+  if (keys.find(b) == keys.end())
+    return false;
+  return true;
 }
 
-bool Section::has_sect(const string &b) const {
-	if (sects.find(b) == sects.end())
-		return false;
-	return true;
-
+bool Section::has_sect(const string & b) const {
+  if (sects.find(b) == sects.end())
+    return false;
+  return true;
 }
 
-bool Section::has_tag(const string &b) const {
-	if (tags.find(b) == tags.end())
-		return false;
-	return true;
-
+bool Section::has_tag(const string & b) const {
+  if (tags.find(b) == tags.end())
+    return false;
+  return true;
 }
 
-void Section::print() const
-{
-	cout << &repr(cout) << endl;
-}
+void Section::print() const { cout << &repr(cout) << endl; }
 
-ostream &Section::repr(ostream &o) const
-{
-	o << endl << name;
-	if (name.compare(tag) != 0) {
-		o << "<" + tag + ">";
-	}
-	o << " {" << endl;
+ostream & Section::repr(ostream & o) const {
+  o << endl << name;
+  if (name.compare(tag) != 0) {
+    o << "<" + tag + ">";
+  }
+  o << " {" << endl;
 
-	map<string, boost::any>::const_iterator iter;
-	for (iter = keys.begin(); iter != keys.end(); ++iter) {
-		IF_ANY_KEYTYPE_IS(iter->second,int) {
-			o << *ANY_TO_CONST_KEY_PTR(iter->second, int) << endl;
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(iter->second,bool) {
-			o << *ANY_TO_CONST_KEY_PTR(iter->second, bool) << endl;
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(iter->second,double) {
-			o << *ANY_TO_CONST_KEY_PTR(iter->second, double) << endl;
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(iter->second, string) {
-			o << *ANY_TO_CONST_KEY_PTR(iter->second, string) << endl;
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(iter->second, vector<int>) {
-			o << *ANY_TO_CONST_KEY_PTR(iter->second, vector<int>) << endl;
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(iter->second, vector<bool>) {
-			o << *ANY_TO_CONST_KEY_PTR(iter->second, vector<bool>) << endl;
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(iter->second, vector<double>) {
-			o << *ANY_TO_CONST_KEY_PTR(iter->second, vector<double>) << endl;
-			continue;
-		}
-		IF_ANY_KEYTYPE_IS(iter->second, vector<string>) {
-			o << *ANY_TO_CONST_KEY_PTR(iter->second, vector<string>) << endl;
-			continue;
-		}
-		THROW_GETKW("Unknown key type!");
-	}
+  map<string, boost::any>::const_iterator iter;
+  for (iter = keys.begin(); iter != keys.end(); ++iter) {
+    IF_ANY_KEYTYPE_IS(iter->second, int) {
+      o << *ANY_TO_CONST_KEY_PTR(iter->second, int) << endl;
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(iter->second, bool) {
+      o << *ANY_TO_CONST_KEY_PTR(iter->second, bool) << endl;
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(iter->second, double) {
+      o << *ANY_TO_CONST_KEY_PTR(iter->second, double) << endl;
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(iter->second, string) {
+      o << *ANY_TO_CONST_KEY_PTR(iter->second, string) << endl;
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(iter->second, vector<int>) {
+      o << *ANY_TO_CONST_KEY_PTR(iter->second, vector<int>) << endl;
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(iter->second, vector<bool>) {
+      o << *ANY_TO_CONST_KEY_PTR(iter->second, vector<bool>) << endl;
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(iter->second, vector<double>) {
+      o << *ANY_TO_CONST_KEY_PTR(iter->second, vector<double>) << endl;
+      continue;
+    }
+    IF_ANY_KEYTYPE_IS(iter->second, vector<string>) {
+      o << *ANY_TO_CONST_KEY_PTR(iter->second, vector<string>) << endl;
+      continue;
+    }
+    THROW_GETKW("Unknown key type!");
+  }
 
+  map<string, Section *>::const_iterator s_it;
+  for (s_it = sects.begin(); s_it != sects.end(); ++s_it) {
+    o << *s_it->second << endl;
+  }
 
-	map<string, Section *>::const_iterator s_it;
-	for (s_it = sects.begin(); s_it != sects.end(); ++s_it) {
-		o << *s_it->second << endl;
-	}
-
-	o << "}";
-	return o;
+  o << "}";
+  return o;
 }
 
 template void Section::addKey(const Keyword<int> *);
@@ -404,20 +397,20 @@ template void Section::addKey(const Keyword<vector<double> > &);
 template void Section::addKey(const Keyword<vector<bool> > &);
 template void Section::addKey(const Keyword<vector<string> > &);
 
-template const Keyword<int> &Section::getKey(const string &) const;
-template const Keyword<double> &Section::getKey(const string &) const;
-template const Keyword<bool> &Section::getKey(const string &) const;
-template const Keyword<string> &Section::getKey(const string &) const;
-template const Keyword<vector<int> > &Section::getKey(const string &) const;
-template const Keyword<vector<double> > &Section::getKey(const string &) const;
-template const Keyword<vector<bool> > &Section::getKey(const string &) const;
-template const Keyword<vector<string> > &Section::getKey(const string &) const;
+template const Keyword<int> & Section::getKey(const string &) const;
+template const Keyword<double> & Section::getKey(const string &) const;
+template const Keyword<bool> & Section::getKey(const string &) const;
+template const Keyword<string> & Section::getKey(const string &) const;
+template const Keyword<vector<int> > & Section::getKey(const string &) const;
+template const Keyword<vector<double> > & Section::getKey(const string &) const;
+template const Keyword<vector<bool> > & Section::getKey(const string &) const;
+template const Keyword<vector<string> > & Section::getKey(const string &) const;
 
-template const int &Section::get<int>(const string&) const;
-template const bool &Section::get<bool>(const string&) const;
-template const double &Section::get<double>(const string&) const;
-template const string &Section::get<string>(const string&) const;
-template const vector<int> &Section::get<vector<int> >(const string&) const;
-template const vector<double> &Section::get<vector<double> >(const string&) const;
-template const vector<bool> &Section::get<vector<bool> >(const string&) const;
-template const vector<string> &Section::get<vector<string> >(const string&) const;
+template const int & Section::get<int>(const string &) const;
+template const bool & Section::get<bool>(const string &) const;
+template const double & Section::get<double>(const string &) const;
+template const string & Section::get<string>(const string &) const;
+template const vector<int> & Section::get<vector<int> >(const string &) const;
+template const vector<double> & Section::get<vector<double> >(const string &) const;
+template const vector<bool> & Section::get<vector<bool> >(const string &) const;
+template const vector<string> & Section::get<vector<string> >(const string &) const;

--- a/src/utils/getkw/Section.h
+++ b/src/utils/getkw/Section.h
@@ -10,91 +10,91 @@
 #ifndef SECTION_H_
 #define SECTION_H_
 
-#include <fstream>
-#include <string>
-#include <map>
-#include <vector>
 #include <boost/any.hpp>
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
 
 using namespace std;
 
-#include "Keyword.h"
 #include "GetkwError.h"
+#include "Keyword.h"
 
 class Section {
 public:
-	Section(const std::string &name, const std::string &tag = "");
-	Section(const Section &s);
-	Section &operator=(const Section &s);
-	virtual ~Section();
-	const Section &getSect(const std::string &path) const;
-	template<class T> const Keyword<T> &getKey(const std::string &path) const;
-	template<class T> const T &get(const std::string &path) const;
-	void addSect(Section &sect);
-	void addSect(Section *);
-	template <class T> void addKey(const Keyword<T> &key);
-	template<class T> void addKey(const Keyword<T> *key);
-	static Section *readSect(std::ifstream &fis);
-	void print() const;
-	std::ostream &repr(std::ostream &o) const;
+  Section(const std::string & name, const std::string & tag = "");
+  Section(const Section & s);
+  Section & operator=(const Section & s);
+  virtual ~Section();
+  const Section & getSect(const std::string & path) const;
+  template <class T> const Keyword<T> & getKey(const std::string & path) const;
+  template <class T> const T & get(const std::string & path) const;
+  void addSect(Section & sect);
+  void addSect(Section *);
+  template <class T> void addKey(const Keyword<T> & key);
+  template <class T> void addKey(const Keyword<T> * key);
+  static Section * readSect(std::ifstream & fis);
+  void print() const;
+  std::ostream & repr(std::ostream & o) const;
 
-	friend std::ostream& operator << (std::ostream& o, const Section &s) {
-        return s.repr(o);
-    }
-	const std::string &getTag() const {return tag;}
-	int getNkeys() const {return nkeys;}
-	int getNsect() const {return nsect;}
-	void setTag(const std::string tag) {this->tag = tag;}
-	void setNkeys(int nkeys) {this->nkeys = nkeys;}
-	void setNsect(int nsect) {this->nsect = nsect;}
-	bool isDefined() const {return isDefd;}
-	std::string getName() const {return name;}
-	void setDefined(bool isDefd) {this->isDefd = isDefd;}
-	void setName(std::string name) {this->name = name;}
+  friend std::ostream & operator<<(std::ostream & o, const Section & s) {
+    return s.repr(o);
+  }
+  const std::string & getTag() const { return tag; }
+  int getNkeys() const { return nkeys; }
+  int getNsect() const { return nsect; }
+  void setTag(const std::string tag) { this->tag = tag; }
+  void setNkeys(int nkeys) { this->nkeys = nkeys; }
+  void setNsect(int nsect) { this->nsect = nsect; }
+  bool isDefined() const { return isDefd; }
+  std::string getName() const { return name; }
+  void setDefined(bool isDefd) { this->isDefd = isDefd; }
+  void setName(std::string name) { this->name = name; }
 
-	int getInt(const std::string &path) const {return get<int>(path);}
-	double getDbl(const std::string &path) const {return get<double>(path);}
-	bool getBool(const std::string &path) const {return get<bool>(path);}
-	const std::string &getStr(const std::string &path) const {
-        return get<std::string>(path);
-    }
-	const std::vector<int> getIntVec(const std::string &path) const {
-		return get<std::vector<int> >(path);
-	}
-	const std::vector<double> getDblVec(const std::string &path) const {
-		return get<std::vector<double> >(path);
-	}
-	const std::vector<bool> getBoolVec(const std::string &path) const {
-		return get<std::vector<bool> >(path);
-	}
-	const std::vector<std::string> getStrVec(const std::string &path) const {
-		return get<std::vector<std::string> >(path);
-	}
-	const std::vector<std::string> getData(const std::string &path) const {
-		return getStrVec(path);
-	}
+  int getInt(const std::string & path) const { return get<int>(path); }
+  double getDbl(const std::string & path) const { return get<double>(path); }
+  bool getBool(const std::string & path) const { return get<bool>(path); }
+  const std::string & getStr(const std::string & path) const {
+    return get<std::string>(path);
+  }
+  const std::vector<int> getIntVec(const std::string & path) const {
+    return get<std::vector<int> >(path);
+  }
+  const std::vector<double> getDblVec(const std::string & path) const {
+    return get<std::vector<double> >(path);
+  }
+  const std::vector<bool> getBoolVec(const std::string & path) const {
+    return get<std::vector<bool> >(path);
+  }
+  const std::vector<std::string> getStrVec(const std::string & path) const {
+    return get<std::vector<std::string> >(path);
+  }
+  const std::vector<std::string> getData(const std::string & path) const {
+    return getStrVec(path);
+  }
 
 protected:
-	std::string name;
-	std::string tag;
-	int nkeys;
-	int nsect;
-	bool isDefd;
-	std::map<std::string, Section *> sects;
-	std::map<std::string, boost::any> keys;
-	std::map<std::string, Section *> tags;
+  std::string name;
+  std::string tag;
+  int nkeys;
+  int nsect;
+  bool isDefd;
+  std::map<std::string, Section *> sects;
+  std::map<std::string, boost::any> keys;
+  std::map<std::string, Section *> tags;
 
-	void copySects(const Section &s);
-	void copyKeys(const Section &s);
-	const Section *findSect(const std::string &pathspec) const;
-	const Section *traversePath(std::vector<std::string> &path,
-						  const std::string &pathspec) const;
-	void splitPath(const std::string &pathspec,
-				   std::vector<std::string> &path) const;
-	int splitTag(const std::string &path, std::string &tag) const;
-	bool has_key(const std::string &name) const;
-	bool has_sect(const std::string &name) const;
-	bool has_tag(const std::string &name) const;
+  void copySects(const Section & s);
+  void copyKeys(const Section & s);
+  const Section * findSect(const std::string & pathspec) const;
+  const Section * traversePath(std::vector<std::string> & path,
+                               const std::string & pathspec) const;
+  void splitPath(const std::string & pathspec,
+                 std::vector<std::string> & path) const;
+  int splitTag(const std::string & path, std::string & tag) const;
+  bool has_key(const std::string & name) const;
+  bool has_sect(const std::string & name) const;
+  bool has_tag(const std::string & name) const;
 };
 
 #endif /* SECTION_H_ */

--- a/src/utils/getkw/messages.cpp
+++ b/src/utils/getkw/messages.cpp
@@ -11,5 +11,4 @@
 #include "messages.h"
 
 int GetkwMessageStream::msg::DebugLevel = 0;
-std::ostream *GetkwMessageStream::msg::out = &std::cout;
-
+std::ostream * GetkwMessageStream::msg::out = &std::cout;

--- a/src/utils/getkw/messages.h
+++ b/src/utils/getkw/messages.h
@@ -1,6 +1,6 @@
 /** @file messages.h
  *
- * @brief Collection of assertions and a standard error/warn/info/debug 
+ * @brief Collection of assertions and a standard error/warn/info/debug
  * message interface.
  *
  * Written by Jonas Juselius <jonas.juselius@chem.uit.no>
@@ -11,37 +11,49 @@
 #define MESSAGES_H
 
 #include <cassert>
-#include <sstream>
 #include <iostream>
+#include <sstream>
 #include <string>
 
 #include "GetkwError.h"
 
 namespace GetkwMessageStream {
 struct msg {
-	static int DebugLevel;
-	static std::ostream *out;
-	static void setOutputStream(std::ostream &o) {
-		out = &o;
-	}
-	static void setDebugLevel(int i) {
-		DebugLevel = i;
-	}
+  static int DebugLevel;
+  static std::ostream * out;
+  static void setOutputStream(std::ostream & o) { out = &o; }
+  static void setDebugLevel(int i) { DebugLevel = i; }
 };
 }
 
-#define STR_DEBUG(S,X) {std::ostringstream _str;\
-	_str << "Debug: " << __func__ << ",  line " << __LINE__ << \
-	" in  " << __FILE__ << ": " << X << endl; S=_str.str();}
-#define STR_INFO(S,X) {std::ostringstream _str;\
-	_str << "Info: " << __func__ << ",  line " << __LINE__ << \
-	" in  " << __FILE__ << ": " << X << endl; S=_str.str();}
-#define STR_WARN(S,X) {std::ostringstream _str;\
-	_str << "Warning: " << __func__ << ",  line " << __LINE__ << \
-	" in  " << __FILE__ << ": " << X << endl; S=_str.str();}
-#define STR_ERROR(S,X) {std::ostringstream _str;\
-	_str << "Error: " << __func__ << ",  line " << __LINE__ << \
-	" in  " << __FILE__ << ": " << X << endl; S=_str.str();}
+#define STR_DEBUG(S, X)                                                             \
+  {                                                                                 \
+    std::ostringstream _str;                                                        \
+    _str << "Debug: " << __func__ << ",  line " << __LINE__ << " in  " << __FILE__  \
+         << ": " << X << endl;                                                      \
+    S = _str.str();                                                                 \
+  }
+#define STR_INFO(S, X)                                                              \
+  {                                                                                 \
+    std::ostringstream _str;                                                        \
+    _str << "Info: " << __func__ << ",  line " << __LINE__ << " in  " << __FILE__   \
+         << ": " << X << endl;                                                      \
+    S = _str.str();                                                                 \
+  }
+#define STR_WARN(S, X)                                                              \
+  {                                                                                 \
+    std::ostringstream _str;                                                        \
+    _str << "Warning: " << __func__ << ",  line " << __LINE__ << " in  "            \
+         << __FILE__ << ": " << X << endl;                                          \
+    S = _str.str();                                                                 \
+  }
+#define STR_ERROR(S, X)                                                             \
+  {                                                                                 \
+    std::ostringstream _str;                                                        \
+    _str << "Error: " << __func__ << ",  line " << __LINE__ << " in  " << __FILE__  \
+         << ": " << X << endl;                                                      \
+    S = _str.str();                                                                 \
+  }
 
 #ifdef NDEBUG
 #define PRINT(STR)
@@ -51,83 +63,160 @@ struct msg {
 #define SPRINT(_out, STR) _out << STR;
 #endif
 
-#define debug(level, STR) if (level < GetkwMessageStream::msg::DebugLevel) \
-		*GetkwMessageStream::msg::out << STR;
-#define sdebug(level, _out, STR) if (level < GetkwMessageStream::msg::DebugLevel) \
-		_out << STR;
+#define debug(level, STR)                                                           \
+  if (level < GetkwMessageStream::msg::DebugLevel)                                  \
+    *GetkwMessageStream::msg::out << STR;
+#define sdebug(level, _out, STR)                                                    \
+  if (level < GetkwMessageStream::msg::DebugLevel)                                  \
+    _out << STR;
 
 #define SET_DEBUG_LEVEL(a) GetkwMessageStream::msg::setDebugLevel(a);
 #define SET_MESSAGE_STREAM(s) GetkwMessageStream::msg::setOutputStrem(s);
 #define DEBUG_LEVEL GetkwMessageStream::msg::DebugLevel
 
-#define MSG_DEBUG(X) { *GetkwMessageStream::msg::out << "Debug: " << \
-   	__func__ << "(), line " << __LINE__ << "in " << \
-   	__FILE__ << ": " << X << endl;}
-#define MSG_INFO(X) { *GetkwMessageStream::msg::out << "Info: " << __FILE__ << ": " <<\
-	__func__ << "(), line " << __LINE__ << ": " << X << endl;}
-#define MSG_NOTE(X) { *GetkwMessageStream::msg::out << "Note: " << __FILE__ << ": " <<\
-	__func__ << "(), line " << __LINE__ << ": " << X << endl;}
-#define MSG_WARN(X) { *GetkwMessageStream::msg::out << "Warning: " \
-	<< __func__ << "(), line " << __LINE__ << ": " << X << endl;}
-#define MSG_ERROR(X) { *GetkwMessageStream::msg::out << "Error: " << \
-	__func__ << "(), line " << __LINE__ << ": " << X << endl;}
-#define MSG_FATAL(X) { *GetkwMessageStream::msg::out << "Error: " << __FILE__ << ": " << \
-	__func__ << "(), line " << __LINE__ << ": " << X << endl; abort();}
+#define MSG_DEBUG(X)                                                                \
+  {                                                                                 \
+    *GetkwMessageStream::msg::out << "Debug: " << __func__ << "(), line "           \
+                                  << __LINE__ << "in " << __FILE__ << ": " << X     \
+                                  << endl;                                          \
+  }
+#define MSG_INFO(X)                                                                 \
+  {                                                                                 \
+    *GetkwMessageStream::msg::out << "Info: " << __FILE__ << ": " << __func__       \
+                                  << "(), line " << __LINE__ << ": " << X << endl;  \
+  }
+#define MSG_NOTE(X)                                                                 \
+  {                                                                                 \
+    *GetkwMessageStream::msg::out << "Note: " << __FILE__ << ": " << __func__       \
+                                  << "(), line " << __LINE__ << ": " << X << endl;  \
+  }
+#define MSG_WARN(X)                                                                 \
+  {                                                                                 \
+    *GetkwMessageStream::msg::out << "Warning: " << __func__ << "(), line "         \
+                                  << __LINE__ << ": " << X << endl;                 \
+  }
+#define MSG_ERROR(X)                                                                \
+  {                                                                                 \
+    *GetkwMessageStream::msg::out << "Error: " << __func__ << "(), line "           \
+                                  << __LINE__ << ": " << X << endl;                 \
+  }
+#define MSG_FATAL(X)                                                                \
+  {                                                                                 \
+    *GetkwMessageStream::msg::out << "Error: " << __FILE__ << ": " << __func__      \
+                                  << "(), line " << __LINE__ << ": " << X << endl;  \
+    abort();                                                                        \
+  }
 
-#define MSG_INVALID_ARG(X) { *GetkwMessageStream::msg::out << \
-	"Error, invalid argument passed: " << __func__ << "(), line " <<\
-   	__LINE__ << ": " << X << endl;}
-#define INVALID_ARG_ABORT { *GetkwMessageStream::msg::out << \
-	"Error, invalid argument passed: " << __func__ << "(), line " <<\
-   	__LINE__ << endl; abort();}
-#define NOT_REACHED_ABORT { *GetkwMessageStream::msg::out << \
-	"Error, should not be reached: " << __func__ << "(), line " <<\
-   	__LINE__ << endl; abort();}
-#define INTERNAL_INCONSISTENCY { *GetkwMessageStream::msg::out << \
-	"Internal inconsistency! You have found a bug: " << __func__ << "(), line " <<\
-   	__LINE__ << endl; abort();}
+#define MSG_INVALID_ARG(X)                                                          \
+  {                                                                                 \
+    *GetkwMessageStream::msg::out << "Error, invalid argument passed: " << __func__ \
+                                  << "(), line " << __LINE__ << ": " << X << endl;  \
+  }
+#define INVALID_ARG_ABORT                                                           \
+  {                                                                                 \
+    *GetkwMessageStream::msg::out << "Error, invalid argument passed: " << __func__ \
+                                  << "(), line " << __LINE__ << endl;               \
+    abort();                                                                        \
+  }
+#define NOT_REACHED_ABORT                                                           \
+  {                                                                                 \
+    *GetkwMessageStream::msg::out << "Error, should not be reached: " << __func__   \
+                                  << "(), line " << __LINE__ << endl;               \
+    abort();                                                                        \
+  }
+#define INTERNAL_INCONSISTENCY                                                      \
+  {                                                                                 \
+    *GetkwMessageStream::msg::out                                                   \
+        << "Internal inconsistency! You have found a bug: " << __func__             \
+        << "(), line " << __LINE__ << endl;                                         \
+    abort();                                                                        \
+  }
 
-#define NEEDS_TESTING {static bool __once = true;\
-	if (__once) { __once = false;\
-	*GetkwMessageStream::msg::out << "NEEDS TESTING: " << __FILE__ << ", " << \
-	__func__ << "(), line " << __LINE__ <<  endl;}}
+#define NEEDS_TESTING                                                               \
+  {                                                                                 \
+    static bool __once = true;                                                      \
+    if (__once) {                                                                   \
+      __once = false;                                                               \
+      *GetkwMessageStream::msg::out << "NEEDS TESTING: " << __FILE__ << ", "        \
+                                    << __func__ << "(), line " << __LINE__ << endl; \
+    }                                                                               \
+  }
 
-#define ASSERT_FILE(A,B) {if (A == NULL) {\
-  	*GetkwMessageStream::msg::out << "Error: " << __func__ << "(), line " << __LINE__ << \
-	": No such file, " << B << endl; abort();}}
+#define ASSERT_FILE(A, B)                                                           \
+  {                                                                                 \
+    if (A == NULL) {                                                                \
+      *GetkwMessageStream::msg::out << "Error: " << __func__ << "(), line "         \
+                                    << __LINE__ << ": No such file, " << B << endl; \
+      abort();                                                                      \
+    }                                                                               \
+  }
 
-#define NOT_IMPLEMENTED_ABORT {*GetkwMessageStream::msg::out << \
-	"Error: Not implemented, " << __FILE__ ", " << __func__ << "(), line " << __LINE__ << \
-	endl; abort();}
+#define NOT_IMPLEMENTED_ABORT                                                       \
+  {                                                                                 \
+    *GetkwMessageStream::msg::out << "Error: Not implemented, " << __FILE__ ", "    \
+                                  << __func__ << "(), line " << __LINE__ << endl;   \
+    abort();                                                                        \
+  }
 
-#define NOTE(X) {static bool __once = true;\
-	if (__once) { __once = false; *GetkwMessageStream::msg::out << \
-	"NOTE: " << __FILE__ << ", " << __func__ << "(), line " << __LINE__ << ": " << X << \
-	endl; }}
+#define NOTE(X)                                                                     \
+  {                                                                                 \
+    static bool __once = true;                                                      \
+    if (__once) {                                                                   \
+      __once = false;                                                               \
+      *GetkwMessageStream::msg::out << "NOTE: " << __FILE__ << ", " << __func__     \
+                                    << "(), line " << __LINE__ << ": " << X         \
+                                    << endl;                                        \
+    }                                                                               \
+  }
 
-#define NEEDS_FIX(X) {static bool __once = true;\
-	if (__once) { __once = false; *GetkwMessageStream::msg::out << \
-	"NEEDS FIX: " << __FILE__ << ", " << __func__ << "(), line " << __LINE__ << ": " << X << \
-	endl; }}
+#define NEEDS_FIX(X)                                                                \
+  {                                                                                 \
+    static bool __once = true;                                                      \
+    if (__once) {                                                                   \
+      __once = false;                                                               \
+      *GetkwMessageStream::msg::out << "NEEDS FIX: " << __FILE__ << ", "            \
+                                    << __func__ << "(), line " << __LINE__ << ": "  \
+                                    << X << endl;                                   \
+    }                                                                               \
+  }
 
-#define WRONG(X) {*GetkwMessageStream::msg::out << \
-	"WRONG: " << __FILE__ << ", " << __func__ << "(), line " << __LINE__ << ": " << X << \
-	endl; abort();}
+#define WRONG(X)                                                                    \
+  {                                                                                 \
+    *GetkwMessageStream::msg::out << "WRONG: " << __FILE__ << ", " << __func__      \
+                                  << "(), line " << __LINE__ << ": " << X << endl;  \
+    abort();                                                                        \
+  }
 
-#define STR_DEBUG(S,X) {std::ostringstream _str;\
-	_str << "Debug: " << __func__ << ",  line " << __LINE__ << \
-	" in  " << __FILE__ << ": " << X << endl; S=_str.str();}
-#define STR_INFO(S,X) {std::ostringstream _str;\
-	_str << "Info: " << __func__ << ",  line " << __LINE__ << \
-	" in  " << __FILE__ << ": " << X << endl; S=_str.str();}
-#define STR_WARN(S,X) {std::ostringstream _str;\
-	_str << "Warning: " << __func__ << ",  line " << __LINE__ << \
-	" in  " << __FILE__ << ": " << X << endl; S=_str.str();}
-#define STR_ERROR(S,X) {std::ostringstream _str;\
-	_str << "Error: " << __func__ << ",  line " << __LINE__ << \
-	" in  " << __FILE__ << ": " << X << endl; S=_str.str();}
+#define STR_DEBUG(S, X)                                                             \
+  {                                                                                 \
+    std::ostringstream _str;                                                        \
+    _str << "Debug: " << __func__ << ",  line " << __LINE__ << " in  " << __FILE__  \
+         << ": " << X << endl;                                                      \
+    S = _str.str();                                                                 \
+  }
+#define STR_INFO(S, X)                                                              \
+  {                                                                                 \
+    std::ostringstream _str;                                                        \
+    _str << "Info: " << __func__ << ",  line " << __LINE__ << " in  " << __FILE__   \
+         << ": " << X << endl;                                                      \
+    S = _str.str();                                                                 \
+  }
+#define STR_WARN(S, X)                                                              \
+  {                                                                                 \
+    std::ostringstream _str;                                                        \
+    _str << "Warning: " << __func__ << ",  line " << __LINE__ << " in  "            \
+         << __FILE__ << ": " << X << endl;                                          \
+    S = _str.str();                                                                 \
+  }
+#define STR_ERROR(S, X)                                                             \
+  {                                                                                 \
+    std::ostringstream _str;                                                        \
+    _str << "Error: " << __func__ << ",  line " << __LINE__ << " in  " << __FILE__  \
+         << ": " << X << endl;                                                      \
+    S = _str.str();                                                                 \
+  }
 
-/* The quiet versions... 
+/* The quiet versions...
  #define SET_DEBUG_LEVEL(a)
  #define SET_MESSAGE_STREAM(s)
  #define DEBUG_LEVEL

--- a/tests/C_host/C_host-functions.h
+++ b/tests/C_host/C_host-functions.h
@@ -53,6 +53,8 @@ typedef enum { false, true } bool;
 
 #define M_PI 3.14159265358979323846
 
+void host_writer(const char * message);
+
 struct PCMInput pcmsolver_input();
 
 /*! \brief calculates nuclear molecular electrostatic potential (MEP) at cavity

--- a/tests/C_host/C_host.c
+++ b/tests/C_host/C_host.c
@@ -26,8 +26,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "pcmsolver.h"
 #include "PCMInput.h"
+#include "pcmsolver.h"
 
 #include "C_host-functions.h"
 

--- a/tests/C_host/fail-C_host.c
+++ b/tests/C_host/fail-C_host.c
@@ -26,8 +26,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "pcmsolver.h"
 #include "PCMInput.h"
+#include "pcmsolver.h"
 
 #include "C_host-functions.h"
 

--- a/tests/bi_operators/bi_operators_collocation.cpp
+++ b/tests/bi_operators/bi_operators_collocation.cpp
@@ -24,17 +24,17 @@
 #include "catch.hpp"
 
 #include <cmath>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <limits>
 
 #include <Eigen/Core>
 
+#include "TestingMolecules.hpp"
+#include "bi_operators/Collocation.hpp"
 #include "cavity/Element.hpp"
 #include "cavity/GePolCavity.hpp"
-#include "bi_operators/Collocation.hpp"
 #include "green/SphericalDiffuse.hpp"
-#include "TestingMolecules.hpp"
 #include "green/UniformDielectric.hpp"
 #include "green/Vacuum.hpp"
 #include "utils/MathUtils.hpp"

--- a/tests/bi_operators/bi_operators_numerical.cpp
+++ b/tests/bi_operators/bi_operators_numerical.cpp
@@ -24,19 +24,19 @@
 #include "catch.hpp"
 
 #include <cmath>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <limits>
 
 #include <Eigen/Core>
 
-#include "green/AnisotropicLiquid.hpp"
+#include "TestingMolecules.hpp"
+#include "bi_operators/Numerical.hpp"
 #include "cavity/Element.hpp"
 #include "cavity/GePolCavity.hpp"
+#include "green/AnisotropicLiquid.hpp"
 #include "green/IonicLiquid.hpp"
-#include "bi_operators/Numerical.hpp"
 #include "green/UniformDielectric.hpp"
-#include "TestingMolecules.hpp"
 #include "green/Vacuum.hpp"
 #include "utils/MathUtils.hpp"
 

--- a/tests/bi_operators/bi_operators_purisima.cpp
+++ b/tests/bi_operators/bi_operators_purisima.cpp
@@ -24,17 +24,17 @@
 #include "catch.hpp"
 
 #include <cmath>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <limits>
 
 #include <Eigen/Core>
 
+#include "TestingMolecules.hpp"
+#include "bi_operators/Purisima.hpp"
 #include "cavity/Element.hpp"
 #include "cavity/GePolCavity.hpp"
-#include "bi_operators/Purisima.hpp"
 #include "green/SphericalDiffuse.hpp"
-#include "TestingMolecules.hpp"
 #include "green/UniformDielectric.hpp"
 #include "green/Vacuum.hpp"
 #include "utils/MathUtils.hpp"

--- a/tests/bi_operators/update_reference_files.cpp
+++ b/tests/bi_operators/update_reference_files.cpp
@@ -23,21 +23,21 @@
 
 #include <cmath>
 #include <cstdlib>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <limits>
 
 #include <Eigen/Core>
 
+#include "TestingMolecules.hpp"
 #include "bi_operators/Collocation.hpp"
-#include "bi_operators/Purisima.hpp"
 #include "bi_operators/Numerical.hpp"
+#include "bi_operators/Purisima.hpp"
 #include "cavity/Element.hpp"
 #include "cavity/GePolCavity.hpp"
-#include "green/SphericalDiffuse.hpp"
-#include "TestingMolecules.hpp"
 #include "green/AnisotropicLiquid.hpp"
 #include "green/IonicLiquid.hpp"
+#include "green/SphericalDiffuse.hpp"
 #include "green/SphericalDiffuse.hpp"
 #include "green/UniformDielectric.hpp"
 #include "green/Vacuum.hpp"

--- a/tests/cpcm/cpcm_gepol-C2H4_D2h.cpp
+++ b/tests/cpcm/cpcm_gepol-C2H4_D2h.cpp
@@ -28,14 +28,14 @@
 
 #include <Eigen/Core>
 
-#include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
-#include "cavity/GePolCavity.hpp"
-#include "utils/Molecule.hpp"
-#include "green/Vacuum.hpp"
-#include "green/UniformDielectric.hpp"
-#include "solver/CPCMSolver.hpp"
 #include "TestingMolecules.hpp"
+#include "bi_operators/Collocation.hpp"
+#include "cavity/GePolCavity.hpp"
+#include "green/DerivativeTypes.hpp"
+#include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
+#include "solver/CPCMSolver.hpp"
+#include "utils/Molecule.hpp"
 
 using namespace pcm;
 using bi_operators::Collocation;

--- a/tests/cpcm/cpcm_gepol-H2O.cpp
+++ b/tests/cpcm/cpcm_gepol-H2O.cpp
@@ -27,15 +27,15 @@
 
 #include <Eigen/Core>
 
-#include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
-#include "cavity/GePolCavity.hpp"
-#include "utils/Molecule.hpp"
-#include "green/Vacuum.hpp"
-#include "green/UniformDielectric.hpp"
-#include "solver/CPCMSolver.hpp"
-#include "utils/Symmetry.hpp"
 #include "TestingMolecules.hpp"
+#include "bi_operators/Collocation.hpp"
+#include "cavity/GePolCavity.hpp"
+#include "green/DerivativeTypes.hpp"
+#include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
+#include "solver/CPCMSolver.hpp"
+#include "utils/Molecule.hpp"
+#include "utils/Symmetry.hpp"
 
 using namespace pcm;
 using bi_operators::Collocation;

--- a/tests/cpcm/cpcm_gepol-NH3.cpp
+++ b/tests/cpcm/cpcm_gepol-NH3.cpp
@@ -27,15 +27,15 @@
 
 #include <Eigen/Core>
 
-#include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
-#include "cavity/GePolCavity.hpp"
-#include "utils/Molecule.hpp"
-#include "green/Vacuum.hpp"
-#include "green/UniformDielectric.hpp"
-#include "solver/CPCMSolver.hpp"
-#include "utils/Symmetry.hpp"
 #include "TestingMolecules.hpp"
+#include "bi_operators/Collocation.hpp"
+#include "cavity/GePolCavity.hpp"
+#include "green/DerivativeTypes.hpp"
+#include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
+#include "solver/CPCMSolver.hpp"
+#include "utils/Molecule.hpp"
+#include "utils/Symmetry.hpp"
 
 using namespace pcm;
 using bi_operators::Collocation;

--- a/tests/cpcm/cpcm_gepol-NH3_from-file.cpp
+++ b/tests/cpcm/cpcm_gepol-NH3_from-file.cpp
@@ -28,10 +28,10 @@
 #include <Eigen/Core>
 
 #include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
 #include "cavity/GePolCavity.hpp"
-#include "green/Vacuum.hpp"
+#include "green/DerivativeTypes.hpp"
 #include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
 #include "solver/CPCMSolver.hpp"
 
 using namespace pcm;

--- a/tests/cpcm/cpcm_gepol-point.cpp
+++ b/tests/cpcm/cpcm_gepol-point.cpp
@@ -27,13 +27,13 @@
 
 #include <Eigen/Core>
 
-#include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
-#include "cavity/GePolCavity.hpp"
-#include "green/Vacuum.hpp"
-#include "green/UniformDielectric.hpp"
-#include "solver/CPCMSolver.hpp"
 #include "TestingMolecules.hpp"
+#include "bi_operators/Collocation.hpp"
+#include "cavity/GePolCavity.hpp"
+#include "green/DerivativeTypes.hpp"
+#include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
+#include "solver/CPCMSolver.hpp"
 
 using namespace pcm;
 using bi_operators::Collocation;

--- a/tests/cpcm/cpcm_gepol-point_from-file.cpp
+++ b/tests/cpcm/cpcm_gepol-point_from-file.cpp
@@ -28,10 +28,10 @@
 #include <Eigen/Core>
 
 #include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
 #include "cavity/GePolCavity.hpp"
-#include "green/Vacuum.hpp"
+#include "green/DerivativeTypes.hpp"
 #include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
 #include "solver/CPCMSolver.hpp"
 
 using namespace pcm;

--- a/tests/cpcm/cpcm_symmetry.cpp
+++ b/tests/cpcm/cpcm_symmetry.cpp
@@ -27,13 +27,13 @@
 
 #include <Eigen/Core>
 
-#include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
-#include "cavity/GePolCavity.hpp"
-#include "green/Vacuum.hpp"
-#include "green/UniformDielectric.hpp"
-#include "solver/CPCMSolver.hpp"
 #include "TestingMolecules.hpp"
+#include "bi_operators/Collocation.hpp"
+#include "cavity/GePolCavity.hpp"
+#include "green/DerivativeTypes.hpp"
+#include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
+#include "solver/CPCMSolver.hpp"
 
 using namespace pcm;
 using bi_operators::Collocation;

--- a/tests/dielectric_profile/one_layer.cpp
+++ b/tests/dielectric_profile/one_layer.cpp
@@ -31,8 +31,8 @@
 #include <Eigen/Core>
 #include <boost/math/special_functions/erf.hpp>
 
-#include "green/dielectric_profile/OneLayerTanh.hpp"
 #include "green/dielectric_profile/OneLayerErf.hpp"
+#include "green/dielectric_profile/OneLayerTanh.hpp"
 
 double tanh_value(double point, double e1, double e2, double w, double c);
 double tanh_deriv(double point, double e1, double e2, double w, double c);

--- a/tests/gepol/gepol_C2H4_D2h.cpp
+++ b/tests/gepol/gepol_C2H4_D2h.cpp
@@ -28,10 +28,10 @@
 
 #include <Eigen/Core>
 
+#include "TestingMolecules.hpp"
 #include "cavity/GePolCavity.hpp"
 #include "utils/Molecule.hpp"
 #include "utils/Symmetry.hpp"
-#include "TestingMolecules.hpp"
 
 using namespace pcm;
 using cavity::GePolCavity;

--- a/tests/gepol/gepol_C6H6.cpp
+++ b/tests/gepol/gepol_C6H6.cpp
@@ -27,10 +27,10 @@
 
 #include <Eigen/Core>
 
+#include "TestingMolecules.hpp"
 #include "cavity/GePolCavity.hpp"
 #include "utils/Molecule.hpp"
 #include "utils/Symmetry.hpp"
-#include "TestingMolecules.hpp"
 
 using namespace pcm;
 using cavity::GePolCavity;

--- a/tests/gepol/gepol_CH3+_Cs.cpp
+++ b/tests/gepol/gepol_CH3+_Cs.cpp
@@ -27,10 +27,10 @@
 
 #include <Eigen/Core>
 
+#include "TestingMolecules.hpp"
 #include "cavity/GePolCavity.hpp"
 #include "utils/Molecule.hpp"
 #include "utils/Symmetry.hpp"
-#include "TestingMolecules.hpp"
 
 using namespace pcm;
 using cavity::GePolCavity;

--- a/tests/gepol/gepol_CO2_symmetry.cpp
+++ b/tests/gepol/gepol_CO2_symmetry.cpp
@@ -27,10 +27,10 @@
 
 #include <Eigen/Core>
 
+#include "TestingMolecules.hpp"
 #include "cavity/GePolCavity.hpp"
 #include "utils/Molecule.hpp"
 #include "utils/Symmetry.hpp"
-#include "TestingMolecules.hpp"
 
 using namespace pcm;
 using cavity::GePolCavity;

--- a/tests/gepol/gepol_H3+.cpp
+++ b/tests/gepol/gepol_H3+.cpp
@@ -27,10 +27,10 @@
 
 #include <Eigen/Core>
 
+#include "TestingMolecules.hpp"
 #include "cavity/GePolCavity.hpp"
 #include "utils/Molecule.hpp"
 #include "utils/Symmetry.hpp"
-#include "TestingMolecules.hpp"
 
 using namespace pcm;
 using cavity::GePolCavity;

--- a/tests/gepol/gepol_H3+_C2v.cpp
+++ b/tests/gepol/gepol_H3+_C2v.cpp
@@ -27,10 +27,10 @@
 
 #include <Eigen/Core>
 
+#include "TestingMolecules.hpp"
 #include "cavity/GePolCavity.hpp"
 #include "utils/Molecule.hpp"
 #include "utils/Symmetry.hpp"
-#include "TestingMolecules.hpp"
 
 using namespace pcm;
 using cavity::GePolCavity;

--- a/tests/gepol/gepol_H3+_from-file.cpp
+++ b/tests/gepol/gepol_H3+_from-file.cpp
@@ -23,8 +23,8 @@
 
 #include <catch.hpp>
 
-#include <vector>
 #include <cmath>
+#include <vector>
 
 #include <Eigen/Core>
 

--- a/tests/gepol/gepol_NH3.cpp
+++ b/tests/gepol/gepol_NH3.cpp
@@ -23,15 +23,15 @@
 
 #include "catch.hpp"
 
-#include <vector>
 #include <cmath>
+#include <vector>
 
 #include <Eigen/Core>
 
-#include "cavity/GePolCavity.hpp"
 #include "LoggerInterface.hpp"
-#include "utils/Molecule.hpp"
 #include "TestingMolecules.hpp"
+#include "cavity/GePolCavity.hpp"
+#include "utils/Molecule.hpp"
 #include "utils/Symmetry.hpp"
 
 using namespace pcm;

--- a/tests/gepol/gepol_NH3_from-file.cpp
+++ b/tests/gepol/gepol_NH3_from-file.cpp
@@ -23,8 +23,8 @@
 
 #include <catch.hpp>
 
-#include <vector>
 #include <cmath>
+#include <vector>
 
 #include <Eigen/Core>
 

--- a/tests/gepol/gepol_point.cpp
+++ b/tests/gepol/gepol_point.cpp
@@ -23,13 +23,13 @@
 
 #include "catch.hpp"
 
-#include <vector>
 #include <cmath>
+#include <vector>
 
 #include <Eigen/Core>
 
-#include "cavity/GePolCavity.hpp"
 #include "TestingMolecules.hpp"
+#include "cavity/GePolCavity.hpp"
 
 using namespace pcm;
 using cavity::GePolCavity;

--- a/tests/gepol/gepol_point_from-file.cpp
+++ b/tests/gepol/gepol_point_from-file.cpp
@@ -23,8 +23,8 @@
 
 #include "catch.hpp"
 
-#include <vector>
 #include <cmath>
+#include <vector>
 
 #include <Eigen/Core>
 

--- a/tests/gepol/gepol_point_symmetry.cpp
+++ b/tests/gepol/gepol_point_symmetry.cpp
@@ -28,8 +28,8 @@
 
 #include <Eigen/Core>
 
-#include "cavity/GePolCavity.hpp"
 #include "TestingMolecules.hpp"
+#include "cavity/GePolCavity.hpp"
 
 using namespace pcm;
 using cavity::GePolCavity;

--- a/tests/iefpcm/iefpcm_anisotropic-gepol-point.cpp
+++ b/tests/iefpcm/iefpcm_anisotropic-gepol-point.cpp
@@ -27,14 +27,14 @@
 
 #include <Eigen/Core>
 
-#include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
-#include "cavity/GePolCavity.hpp"
-#include "utils/Molecule.hpp"
-#include "green/Vacuum.hpp"
-#include "green/UniformDielectric.hpp"
-#include "solver/IEFSolver.hpp"
 #include "TestingMolecules.hpp"
+#include "bi_operators/Collocation.hpp"
+#include "cavity/GePolCavity.hpp"
+#include "green/DerivativeTypes.hpp"
+#include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
+#include "solver/IEFSolver.hpp"
+#include "utils/Molecule.hpp"
 
 using namespace pcm;
 using bi_operators::Collocation;

--- a/tests/iefpcm/iefpcm_anisotropic-symmetry.cpp
+++ b/tests/iefpcm/iefpcm_anisotropic-symmetry.cpp
@@ -27,13 +27,13 @@
 
 #include <Eigen/Core>
 
-#include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
-#include "cavity/GePolCavity.hpp"
-#include "green/Vacuum.hpp"
-#include "green/UniformDielectric.hpp"
-#include "solver/IEFSolver.hpp"
 #include "TestingMolecules.hpp"
+#include "bi_operators/Collocation.hpp"
+#include "cavity/GePolCavity.hpp"
+#include "green/DerivativeTypes.hpp"
+#include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
+#include "solver/IEFSolver.hpp"
 
 using namespace pcm;
 using bi_operators::Collocation;

--- a/tests/iefpcm/iefpcm_diffuse-gepol-point.cpp
+++ b/tests/iefpcm/iefpcm_diffuse-gepol-point.cpp
@@ -27,14 +27,14 @@
 
 #include <Eigen/Core>
 
+#include "TestingMolecules.hpp"
 #include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
 #include "cavity/GePolCavity.hpp"
-#include "utils/Molecule.hpp"
+#include "green/DerivativeTypes.hpp"
+#include "green/SphericalDiffuse.hpp"
 #include "green/Vacuum.hpp"
 #include "solver/IEFSolver.hpp"
-#include "green/SphericalDiffuse.hpp"
-#include "TestingMolecules.hpp"
+#include "utils/Molecule.hpp"
 
 using namespace pcm;
 using bi_operators::Collocation;

--- a/tests/iefpcm/iefpcm_gepol-C2H4_D2h.cpp
+++ b/tests/iefpcm/iefpcm_gepol-C2H4_D2h.cpp
@@ -28,14 +28,14 @@
 
 #include <Eigen/Core>
 
-#include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
-#include "cavity/GePolCavity.hpp"
-#include "utils/Molecule.hpp"
-#include "green/Vacuum.hpp"
-#include "green/UniformDielectric.hpp"
-#include "solver/IEFSolver.hpp"
 #include "TestingMolecules.hpp"
+#include "bi_operators/Collocation.hpp"
+#include "cavity/GePolCavity.hpp"
+#include "green/DerivativeTypes.hpp"
+#include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
+#include "solver/IEFSolver.hpp"
+#include "utils/Molecule.hpp"
 
 using namespace pcm;
 using bi_operators::Collocation;

--- a/tests/iefpcm/iefpcm_gepol-NH3.cpp
+++ b/tests/iefpcm/iefpcm_gepol-NH3.cpp
@@ -27,14 +27,14 @@
 
 #include <Eigen/Core>
 
-#include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
-#include "cavity/GePolCavity.hpp"
-#include "utils/Molecule.hpp"
-#include "green/Vacuum.hpp"
 #include "TestingMolecules.hpp"
+#include "bi_operators/Collocation.hpp"
+#include "cavity/GePolCavity.hpp"
+#include "green/DerivativeTypes.hpp"
 #include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
 #include "solver/IEFSolver.hpp"
+#include "utils/Molecule.hpp"
 #include "utils/Symmetry.hpp"
 
 using namespace pcm;

--- a/tests/iefpcm/iefpcm_gepol-NH3_from-file.cpp
+++ b/tests/iefpcm/iefpcm_gepol-NH3_from-file.cpp
@@ -28,10 +28,10 @@
 #include <Eigen/Core>
 
 #include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
 #include "cavity/GePolCavity.hpp"
-#include "green/Vacuum.hpp"
+#include "green/DerivativeTypes.hpp"
 #include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
 #include "solver/IEFSolver.hpp"
 
 using namespace pcm;

--- a/tests/iefpcm/iefpcm_gepol-point.cpp
+++ b/tests/iefpcm/iefpcm_gepol-point.cpp
@@ -27,13 +27,13 @@
 
 #include <Eigen/Core>
 
-#include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
-#include "cavity/GePolCavity.hpp"
-#include "green/Vacuum.hpp"
-#include "green/UniformDielectric.hpp"
-#include "solver/IEFSolver.hpp"
 #include "TestingMolecules.hpp"
+#include "bi_operators/Collocation.hpp"
+#include "cavity/GePolCavity.hpp"
+#include "green/DerivativeTypes.hpp"
+#include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
+#include "solver/IEFSolver.hpp"
 
 using namespace pcm;
 using bi_operators::Collocation;

--- a/tests/iefpcm/iefpcm_gepol-point_from-file.cpp
+++ b/tests/iefpcm/iefpcm_gepol-point_from-file.cpp
@@ -28,12 +28,12 @@
 #include <Eigen/Core>
 
 #include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
 #include "cavity/GePolCavity.hpp"
-#include "utils/Molecule.hpp"
-#include "green/Vacuum.hpp"
+#include "green/DerivativeTypes.hpp"
 #include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
 #include "solver/IEFSolver.hpp"
+#include "utils/Molecule.hpp"
 
 using namespace pcm;
 using bi_operators::Collocation;

--- a/tests/iefpcm/iefpcm_symmetry.cpp
+++ b/tests/iefpcm/iefpcm_symmetry.cpp
@@ -27,14 +27,14 @@
 
 #include <Eigen/Core>
 
-#include "bi_operators/Collocation.hpp"
-#include "green/DerivativeTypes.hpp"
-#include "cavity/GePolCavity.hpp"
-#include "utils/Molecule.hpp"
-#include "green/Vacuum.hpp"
-#include "green/UniformDielectric.hpp"
-#include "solver/IEFSolver.hpp"
 #include "TestingMolecules.hpp"
+#include "bi_operators/Collocation.hpp"
+#include "cavity/GePolCavity.hpp"
+#include "green/DerivativeTypes.hpp"
+#include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
+#include "solver/IEFSolver.hpp"
+#include "utils/Molecule.hpp"
 
 using namespace pcm;
 using bi_operators::Collocation;

--- a/tests/input/input_diffuse.cpp
+++ b/tests/input/input_diffuse.cpp
@@ -32,8 +32,8 @@
 #include "bi_operators/BIOperatorData.hpp"
 #include "cavity/CavityData.hpp"
 #include "green/GreenData.hpp"
-#include "solver/SolverData.hpp"
 #include "interface/Input.hpp"
+#include "solver/SolverData.hpp"
 #include "utils/Sphere.hpp"
 
 using pcm::Input;

--- a/tests/input/input_multipoles.cpp
+++ b/tests/input/input_multipoles.cpp
@@ -36,8 +36,8 @@
 #include "bi_operators/BIOperatorData.hpp"
 #include "cavity/CavityData.hpp"
 #include "green/GreenData.hpp"
-#include "solver/SolverData.hpp"
 #include "interface/Input.hpp"
+#include "solver/SolverData.hpp"
 #include "utils/Sphere.hpp"
 
 using pcm::Input;

--- a/tests/input/input_restart.cpp
+++ b/tests/input/input_restart.cpp
@@ -32,8 +32,8 @@
 #include "bi_operators/BIOperatorData.hpp"
 #include "cavity/CavityData.hpp"
 #include "green/GreenData.hpp"
-#include "solver/SolverData.hpp"
 #include "interface/Input.hpp"
+#include "solver/SolverData.hpp"
 #include "utils/Sphere.hpp"
 
 using pcm::Input;

--- a/tests/input/input_tsless.cpp
+++ b/tests/input/input_tsless.cpp
@@ -32,8 +32,8 @@
 #include "bi_operators/BIOperatorData.hpp"
 #include "cavity/CavityData.hpp"
 #include "green/GreenData.hpp"
-#include "solver/SolverData.hpp"
 #include "interface/Input.hpp"
+#include "solver/SolverData.hpp"
 #include "utils/Sphere.hpp"
 
 using pcm::Input;

--- a/tests/input/input_wavelet.cpp
+++ b/tests/input/input_wavelet.cpp
@@ -32,8 +32,8 @@
 #include "bi_operators/BIOperatorData.hpp"
 #include "cavity/CavityData.hpp"
 #include "green/GreenData.hpp"
-#include "solver/SolverData.hpp"
 #include "interface/Input.hpp"
+#include "solver/SolverData.hpp"
 #include "utils/Sphere.hpp"
 
 using pcm::Input;

--- a/tests/make_cmake_files.py
+++ b/tests/make_cmake_files.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-
 #
 #  PCMSolver, an API for the Polarizable Continuum Model
 #  Copyright (C) 2017 Roberto Di Remigio, Luca Frediani and collaborators.
@@ -33,6 +32,7 @@
 
 import os
 
+
 def glob_sources(dname):
     import glob
     import os
@@ -51,7 +51,7 @@ dname = os.getcwd()
 fname = os.path.join(dname, 'CMakeLists.txt.try')
 f = open(fname, 'w')
 sources = glob_sources(dname)
-labels  = extract_labels(dname, sources)
+labels = extract_labels(dname, sources)
 src_lbl = dict(zip([os.path.basename(src) for src in sources], labels))
 
 dirname = os.path.basename(os.path.normpath(dname))

--- a/tests/numerical_quadrature/numerical_quadrature.cpp
+++ b/tests/numerical_quadrature/numerical_quadrature.cpp
@@ -30,12 +30,12 @@
 
 #include <Eigen/Core>
 
-#include "utils/cnpy.hpp"
+#include "TestingMolecules.hpp"
+#include "bi_operators/Numerical.hpp"
 #include "cavity/Element.hpp"
 #include "cavity/GePolCavity.hpp"
-#include "bi_operators/Numerical.hpp"
 #include "utils/MathUtils.hpp"
-#include "TestingMolecules.hpp"
+#include "utils/cnpy.hpp"
 
 using namespace pcm;
 using bi_operators::integrateS;

--- a/tests/utils/utils_dipolar-potential.cpp
+++ b/tests/utils/utils_dipolar-potential.cpp
@@ -23,17 +23,17 @@
 
 #include "catch.hpp"
 
-#include <vector>
 #include <cmath>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "TestingMolecules.hpp"
 #include "cavity/GePolCavity.hpp"
-#include "green/Vacuum.hpp"
 #include "green/IonicLiquid.hpp"
 #include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
 #include "utils/ChargeDistribution.hpp"
-#include "TestingMolecules.hpp"
 
 using namespace pcm;
 using cavity::GePolCavity;

--- a/tests/utils/utils_newton-potential.cpp
+++ b/tests/utils/utils_newton-potential.cpp
@@ -23,17 +23,17 @@
 
 #include "catch.hpp"
 
-#include <vector>
 #include <cmath>
+#include <vector>
 
 #include <Eigen/Core>
 
+#include "TestingMolecules.hpp"
 #include "cavity/GePolCavity.hpp"
-#include "green/Vacuum.hpp"
 #include "green/IonicLiquid.hpp"
 #include "green/UniformDielectric.hpp"
+#include "green/Vacuum.hpp"
 #include "utils/ChargeDistribution.hpp"
-#include "TestingMolecules.hpp"
 
 using namespace pcm;
 using cavity::GePolCavity;

--- a/tools/codata.py
+++ b/tools/codata.py
@@ -25,6 +25,7 @@
 # -*- coding: utf-8 -*-
 # vim:filetype=python:
 
+
 class CODATA:
     """A class holding conversion factors from atomic units
 
@@ -32,6 +33,7 @@ class CODATA:
            ToAngstrom conversion factor from AU of length to Angstrom
            ToFemtoseconds conversion factor from AU of time to Femtoseconds
     """
+
     def __init__(self, toang, tofs):
         self.ToAngstrom = toang
         self.ToFemtosecond = tofs

--- a/tools/pcmsolver.py.in
+++ b/tools/pcmsolver.py.in
@@ -33,7 +33,6 @@
 # Various modifications by Roberto Di Remigio <roberto.d.remigio@uit.no>
 # University of Pisa, 2011-2012
 # University of Tromso 2013-2014
-
 """
 Parses the PCMSolver input file and generates a machine-readable input file.
 Based on the Getkw library by J. Juselius.
@@ -75,27 +74,28 @@ Options:
 isAngstrom = False
 CODATAyear = 2010
 
-allowedSolvents = {'Water'                : ('WATER',                'H2O'),
-                   'Propylene Carbonate'  : ('PROPYLENE CARBONATE',  'C4H6O3'),
-                   'Dimethylsulfoxide'    : ('DIMETHYLSULFOXIDE',    'DMSO'),
-                   'Nitromethane'         : ('NITROMETHANE',         'CH3NO2'),
-                   'Acetonitrile'         : ('ACETONITRILE',         'CH3CN'),
-                   'Methanol'             : ('METHANOL',             'CH3OH'),
-                   'Ethanol'              : ('ETHANOL',              'CH3CH2OH'),
-                   'Acetone'              : ('ACETONE',              'C2H6CO'),
-                   '1,2-Dichloroethane'   : ('1,2-DICHLOROETHANE',   'C2H4CL2'),
-                   'Methylenechloride'    : ('METHYLENECHLORIDE',    'CH2CL2'),
-                   'Tetrahydrofurane'     : ('TETRAHYDROFURANE',     'THF'),
-                   'Aniline'              : ('ANILINE',              'C6H5NH2'),
-                   'Chlorobenzene'        : ('CHLOROBENZENE',        'C6H5CL'),
-                   'Chloroform'           : ('CHLOROFORM',           'CHCL3'),
-                   'Toluene'              : ('TOLUENE',              'C6H5CH3'),
-                   '1,4-Dioxane'          : ('1,4-DIOXANE',          'C4H8O2'),
-                   'Benzene'              : ('BENZENE',              'C6H6'),
-                   'Carbon Tetrachloride' : ('CARBON TETRACHLORIDE', 'CCL4'),
-                   'Cyclohexane'          : ('CYCLOHEXANE',          'C6H12'),
-                   'N-heptane'            : ('N-HEPTANE',            'C7H16'),
-                   'Explicit'             : ('EXPLICIT',             'DUMMY')}
+allowedSolvents = {'Water': ('WATER', 'H2O'),
+                   'Propylene Carbonate': ('PROPYLENE CARBONATE', 'C4H6O3'),
+                   'Dimethylsulfoxide': ('DIMETHYLSULFOXIDE', 'DMSO'),
+                   'Nitromethane': ('NITROMETHANE', 'CH3NO2'),
+                   'Acetonitrile': ('ACETONITRILE', 'CH3CN'),
+                   'Methanol': ('METHANOL', 'CH3OH'),
+                   'Ethanol': ('ETHANOL', 'CH3CH2OH'),
+                   'Acetone': ('ACETONE', 'C2H6CO'),
+                   '1,2-Dichloroethane': ('1,2-DICHLOROETHANE', 'C2H4CL2'),
+                   'Methylenechloride': ('METHYLENECHLORIDE', 'CH2CL2'),
+                   'Tetrahydrofurane': ('TETRAHYDROFURANE', 'THF'),
+                   'Aniline': ('ANILINE', 'C6H5NH2'),
+                   'Chlorobenzene': ('CHLOROBENZENE', 'C6H5CL'),
+                   'Chloroform': ('CHLOROFORM', 'CHCL3'),
+                   'Toluene': ('TOLUENE', 'C6H5CH3'),
+                   '1,4-Dioxane': ('1,4-DIOXANE', 'C4H8O2'),
+                   'Benzene': ('BENZENE', 'C6H6'),
+                   'Carbon Tetrachloride': ('CARBON TETRACHLORIDE', 'CCL4'),
+                   'Cyclohexane': ('CYCLOHEXANE', 'C6H12'),
+                   'N-heptane': ('N-HEPTANE', 'C7H16'),
+                   'Explicit': ('EXPLICIT', 'DUMMY')}
+
 
 def iequal(a, b):
     """
@@ -105,6 +105,7 @@ def iequal(a, b):
         return a.upper() == b.upper()
     except AttributeError:
         return a == b
+
 
 def convert_to_upper_case(filename):
     """
@@ -132,7 +133,7 @@ def convert_to_upper_case(filename):
     # Convert also occurences of TRUE/FALSE to True/False,
     # Python will otherwise interpret them as strings!
     final = re.sub('FALSE', 'False', final)
-    final = re.sub('TRUE',  'True',  final)
+    final = re.sub('TRUE', 'True', final)
 
     # Write to temporary file in current working directory
     # The temporary file has the name of the input file, joined with a unique id
@@ -194,11 +195,12 @@ def parse_pcm_input(inputFile):
 def execute(parsedFile):
     executable = os.path.join(os.path.dirname(__file__), "run_pcm" + "@CMAKE_EXECUTABLE_SUFFIX@")
     if (executable):
-        p = subprocess.Popen([executable, parsedFile],
-                             shell=False,
-                             stdin=subprocess.PIPE,
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
+        p = subprocess.Popen(
+            [executable, parsedFile],
+            shell=False,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
         stdout_coded, stderr_coded = p.communicate()
         stdout = stdout_coded.decode('UTF-8')
         stderr = stderr_coded.decode('UTF-8')
@@ -221,7 +223,7 @@ def setup_keywords():
     # Define units of measure
     # Valid values: AU (atomic units) or ANGSTROM
     # Default: AU
-    top.add_kw('UNITS',  'STR', 'AU')
+    top.add_kw('UNITS', 'STR', 'AU')
     # Define set of CODATA constants
     # Valid values: 2010, 2006, 2002, 1998
     # Default: 2010
@@ -231,30 +233,30 @@ def setup_keywords():
     cavity = getkw.Section('CAVITY', callback=verify_cavity)
     # Type of the cavity
     # Valid values: GEPOL, WAVELET, TSLESS and RESTART
-    cavity.add_kw('TYPE',        'STR')
+    cavity.add_kw('TYPE', 'STR')
     # Name of the file containing data for restarting a cavity
     # Valid for: Restart cavity
     # Default: empty string
-    cavity.add_kw('NPZFILE',     'STR', '')
+    cavity.add_kw('NPZFILE', 'STR', '')
     # Name of the file containing the list of points for a wavelet cavity
     # Valid for: Wavelet cavity
     # Default: empty string
-    cavity.add_kw('DYADICFILE',     'STR', '')
+    cavity.add_kw('DYADICFILE', 'STR', '')
     # Patch level
     # Valid for: Wavelet cavity
     # Valid values: integer strictly greater than 0
     # Default: 2
-    cavity.add_kw('PATCHLEVEL',  'INT', 2)
+    cavity.add_kw('PATCHLEVEL', 'INT', 2)
     # Coarsity
     # Valid for: Wavelet cavity
     # Valid values: double in ]0.0, 1.0[
     # Default: 0.5
-    cavity.add_kw('COARSITY',    'DBL', 0.5)
+    cavity.add_kw('COARSITY', 'DBL', 0.5)
     # Average area (in au^2)
     # Valid for: GePol and TsLess cavities
     # Valid values: double strictly greater than 0.01 au^2
     # Default: 0.3 au^2
-    cavity.add_kw('AREA',        'DBL', 0.3)
+    cavity.add_kw('AREA', 'DBL', 0.3)
     # Minimal distance between sampling points (in au)
     # Valid for: TsLess cavity
     # Valid values: double
@@ -264,56 +266,56 @@ def setup_keywords():
     # Valid for: TsLess cavity
     # Valid values: integer
     # Default: 4
-    cavity.add_kw('DERORDER',    'INT', 4)
+    cavity.add_kw('DERORDER', 'INT', 4)
     # Scaling of the atomic radii
     # Valid for: GePol, Wavelet and TsLess
     # Valid values: boolean
     # Default: True
-    cavity.add_kw('SCALING',     'BOOL', True)
+    cavity.add_kw('SCALING', 'BOOL', True)
     # Built-in radii set
     # Valid for: GePol, Wavelet and TsLess
     # Valid values: BONDI, UFF or ALLINGER
     # Default: BONDI
-    cavity.add_kw('RADIISET',    'STR', 'BONDI')
+    cavity.add_kw('RADIISET', 'STR', 'BONDI')
     # Minimal radius of added spheres (in au)
     # Valid for: GePol and TsLess
     # Valid values: double greater than 0.4 au
     # Default: 100.0 au (no added spheres)
-    cavity.add_kw('MINRADIUS',   'DBL', 100.0)
+    cavity.add_kw('MINRADIUS', 'DBL', 100.0)
     # Spheres geometry creation mode
     # Valid for: GePol, TsLess and Wavelet
     # Valid values: EXPLICIT, ATOMS or IMPLICIT
     # Default: IMPLICIT
-    cavity.add_kw('MODE',        'STR', 'IMPLICIT')
+    cavity.add_kw('MODE', 'STR', 'IMPLICIT')
     # List of atoms with custom radius
     # Valid for: GePol, TsLess and Wavelet in MODE=ATOMS
     # Valid values: array of integers
-    cavity.add_kw('ATOMS',       'INT_ARRAY')
+    cavity.add_kw('ATOMS', 'INT_ARRAY')
     # List of custom radii
     # Valid for: GePol, TsLess and Wavelet in MODE=ATOMS
     # Valid values: array of doubles
-    cavity.add_kw('RADII',       'DBL_ARRAY')
+    cavity.add_kw('RADII', 'DBL_ARRAY')
     # List of spheres
     # Valid for: GePol, TsLess and Wavelet in MODE=EXPLICIT
     # Valid values: array of doubles in format [x, y, z, R]
-    cavity.add_kw('SPHERES',     'DBL_ARRAY', callback=verify_spheres)
+    cavity.add_kw('SPHERES', 'DBL_ARRAY', callback=verify_spheres)
     top.add_sect(cavity)
 
     # Medium section
     medium = getkw.Section('MEDIUM', callback=verify_medium)
     # Type of solver
     # Valid values: IEFPCM, CPCM, WAVELET or LINEAR
-    medium.add_kw('SOLVERTYPE',   'STR', 'IEFPCM')
+    medium.add_kw('SOLVERTYPE', 'STR', 'IEFPCM')
     # Whether nonequilibrium response is to be used
     # Valid for: IEFPCM, CPCM, WAVELET or LINEAR
     # Valid values: boolean
     # Default: False
-    medium.add_kw('NONEQUILIBRIUM',   'BOOL', False)
+    medium.add_kw('NONEQUILIBRIUM', 'BOOL', False)
     # Solvent
     # Valid for: IEFPCM, CPCM, Wavelet and PWL solvers
     # Valid values: string
     # Default: Explicit
-    medium.add_kw('SOLVENT',      'STR', 'EXPLICIT')
+    medium.add_kw('SOLVENT', 'STR', 'EXPLICIT')
     # Type of integral equation
     # Valid for: Wavelet and PWL
     # Valid values: FIRSTKIND, SECONDKIND or FULL
@@ -322,11 +324,11 @@ def setup_keywords():
     # Valid for: IEFPCM
     # Valid values: boolean
     # Default: True
-    medium.add_kw('MATRIXSYMM',   'BOOL', True)
+    medium.add_kw('MATRIXSYMM', 'BOOL', True)
     # CPCM correction factor
     # Valid for: CPCM
     # Valid values: positive double greater than 0.0
-    medium.add_kw('CORRECTION',   'DBL', 0.0)
+    medium.add_kw('CORRECTION', 'DBL', 0.0)
     # Type of integrator for the diagonal of the boundary integral operators
     # Valid for: IEFPCM, CPCM
     # Valid values: COLLOCATION
@@ -343,7 +345,7 @@ def setup_keywords():
     # Valid for: IEFPCM, CPCM, Wavelet and PWL
     # Valid values: double in [0.1, 100.0] au
     # Default: 1.0
-    medium.add_kw('PROBERADIUS',  'DBL', 1.0)
+    medium.add_kw('PROBERADIUS', 'DBL', 1.0)
     # A priori compression parameter a
     # Valid for: wavelet solvers
     # Valid values: double greater than 1.0
@@ -366,37 +368,37 @@ def setup_keywords():
     # Green's function type
     # Valid values: VACUUM, UNIFORMDIELECTRIC, SPHERICALDIFFUSE, METALSPHERE, GREENSFUNCTIONSUM
     # Default: VACUUM
-    green.add_kw('TYPE',           'STR', 'VACUUM')
+    green.add_kw('TYPE', 'STR', 'VACUUM')
     # Green's function derivative calculation strategy
     # Valid values: NUMERICAL, DERIVATIVE, GRADIENT, HESSIAN
     # Default: DERIVATIVE
     # Notes: all other values for debug purposes only
-    green.add_kw('DER',            'STR', 'DERIVATIVE')
+    green.add_kw('DER', 'STR', 'DERIVATIVE')
     # Static dielectric permittivity
     # Valid for: UNIFORMDIELECTRIC
     # Valid values: positive double greater than 1.0
     # Default: 1.0
-    green.add_kw('EPS',            'DBL', 1.0)
+    green.add_kw('EPS', 'DBL', 1.0)
     # Dynamic dielectric permittivity
     # Valid for: UNIFORMDIELECTRIC
     # Valid values: positive double greater than 1.0
     # Default: 1.0
-    green.add_kw('EPSDYN',            'DBL', 1.0)
+    green.add_kw('EPSDYN', 'DBL', 1.0)
     # Real part of the metal's dielectric permittivity
     # Valid for: METALSPHERE
     # Valid values: positive double greater than 1.0
     # Default: 1.0
-    green.add_kw('EPSRE',          'DBL', 1.0)
+    green.add_kw('EPSRE', 'DBL', 1.0)
     # Imaginary part of the metal's dielectric permittivity
     # Valid for: METALSPHERE
     # Valid values: positive double greater than 1.0
     # Default: 1.0
-    green.add_kw('EPSIMG',         'DBL', 1.0)
+    green.add_kw('EPSIMG', 'DBL', 1.0)
     # Radius of the metal sphere (in au)
     # Valid for: METALSPHERE
     # Valid values: positive double greater than 1.0 au
     # Default: 1.0
-    green.add_kw('SPHERERADIUS',   'DBL', 1.0)
+    green.add_kw('SPHERERADIUS', 'DBL', 1.0)
     # Position of the metal sphere (in au)
     # Valid for: METALSPHERE
     # Valid values: array of doubles
@@ -410,22 +412,22 @@ def setup_keywords():
     # Valid for: SPHERICALDIFFUSE
     # Valid values: positive double greater than 1.0
     # Default: 1.0
-    green.add_kw('EPS1',            'DBL', 1.0)
+    green.add_kw('EPS1', 'DBL', 1.0)
     # Dynamic dielectric permittivity inside the interface
     # Valid for: SPHERICALDIFFUSE
     # Valid values: positive double greater than 1.0
     # Default: 1.0
-    green.add_kw('EPSDYN1',            'DBL', 1.0)
+    green.add_kw('EPSDYN1', 'DBL', 1.0)
     # Static dielectric permittivity outside the interface
     # Valid for: SPHERICALDIFFUSE
     # Valid values: positive double greater than 1.0
     # Default: 1.0
-    green.add_kw('EPS2',            'DBL', 1.0)
+    green.add_kw('EPS2', 'DBL', 1.0)
     # Dynamic dielectric permittivity outside the interface
     # Valid for: SPHERICALDIFFUSE
     # Valid values: positive double greater than 1.0
     # Default: 1.0
-    green.add_kw('EPSDYN2',            'DBL', 1.0)
+    green.add_kw('EPSDYN2', 'DBL', 1.0)
     # Center of the diffuse profile
     # Valid for: SPHERICALDIFFUSE
     # Valid values: positive double
@@ -456,7 +458,7 @@ def setup_keywords():
     # List of geometry and classical point charges
     # Valid values: array of doubles in format [x, y, z, Q]
     # Notes: charges are always in atomic units
-    molecule.add_kw('GEOMETRY',     'DBL_ARRAY', callback=verify_geometry)
+    molecule.add_kw('GEOMETRY', 'DBL_ARRAY', callback=verify_geometry)
     # Calculate the molecular electrostatic potential (MEP) at the cavity for the given molecule
     # Valid values: boolean
     # Default: True
@@ -568,7 +570,8 @@ def verify_cavity(section):
     allowed_modes = ('EXPLICIT', 'ATOMS', 'IMPLICIT')
     mode = section.get('MODE')
     if (mode.get() not in allowed_modes):
-        print(('Cavity creation mode requested {} is not among the allowed modes: {}'.format(mode.get(), allowed_modes)))
+        print(
+            ('Cavity creation mode requested {} is not among the allowed modes: {}'.format(mode.get(), allowed_modes)))
         sys.exit(1)
 
     atoms = section.get('ATOMS')
@@ -613,7 +616,8 @@ def verify_medium(section):
             break
     if (not solventFound):
         print(('Unknown solvent {}'.format(solvent.get())))
-        print(('Choose a solvent from the following list:\n{}\n or specify the solvent data explicitly.'.format(list(allowedSolvents.keys()))))
+        print(('Choose a solvent from the following list:\n{}\n or specify the solvent data explicitly.'.format(
+            list(allowedSolvents.keys()))))
         sys.exit(1)
 
     correction = section.get('CORRECTION')
@@ -669,7 +673,8 @@ def verify_medium(section):
 
 
 def verify_green(section):
-    allowed = ('VACUUM', 'UNIFORMDIELECTRIC', 'SPHERICALDIFFUSE', 'ALTERNATESPHERICALDIFFUSE', 'METALSPHERE', 'GREENSFUNCTIONSUM')
+    allowed = ('VACUUM', 'UNIFORMDIELECTRIC', 'SPHERICALDIFFUSE', 'ALTERNATESPHERICALDIFFUSE', 'METALSPHERE',
+               'GREENSFUNCTIONSUM')
     allowed_der = ('NUMERICAL', 'DERIVATIVE', 'GRADIENT', 'HESSIAN')
     allowed_profiles = ('TANH', 'ERF')
 
@@ -741,8 +746,8 @@ def check_array(name, array, offset):
         j = 0
         for i in range(dim // offset):
             array[j] /= CODATAdict[CODATAyear].ToAngstrom
-            array[j+1] /= CODATAdict[CODATAyear].ToAngstrom
-            array[j+2] /= CODATAdict[CODATAyear].ToAngstrom
+            array[j + 1] /= CODATAdict[CODATAyear].ToAngstrom
+            array[j + 2] /= CODATAdict[CODATAyear].ToAngstrom
             j += offset
 
 

--- a/tools/plot_cavity.py
+++ b/tools/plot_cavity.py
@@ -27,7 +27,6 @@
 
 # Written by Roberto Di Remigio <roberto.d.remigio@uit.no>
 # University of Tromso, 2017
-
 """
 Plot molecular cavity from a compressed NumPy format file.
 Color map the finite elements according to a surface function, saved
@@ -62,6 +61,7 @@ Options:
   -h --help      Show this screen.
 """
 
+
 def shiftedColorMap(cmap, start=0, midpoint=0.5, stop=1.0, name='shiftedcmap'):
     '''
     Function to offset the "center" of a colormap. Useful for
@@ -84,20 +84,16 @@ def shiftedColorMap(cmap, start=0, midpoint=0.5, stop=1.0, name='shiftedcmap'):
           Defaults to 1.0 (no upper ofset). Should be between
           `midpoint` and 1.0.
     '''
-    cdict = {
-        'red': [],
-        'green': [],
-        'blue': [],
-        'alpha': []
-    }
+    cdict = {'red': [], 'green': [], 'blue': [], 'alpha': []}
 
     # regular index to compute the colors
     reg_index = np.linspace(start, stop, 257)
 
     # shifted index to match the data
     shift_index = np.hstack([
-        np.linspace(0.0, midpoint, 128, endpoint=False),
-        np.linspace(midpoint, 1.0, 129, endpoint=True)
+        np.linspace(
+            0.0, midpoint, 128, endpoint=False), np.linspace(
+                midpoint, 1.0, 129, endpoint=True)
     ])
 
     for ri, si in zip(reg_index, shift_index):
@@ -124,7 +120,7 @@ def plot(cavity_npz, surf_func_npy=None):
     centroids = cavity['centers']
 
     # Plot collocation points
-    ax.scatter(centroids[0, :], centroids[1,:], centroids[2,:], c='black', alpha=0.5)
+    ax.scatter(centroids[0, :], centroids[1, :], centroids[2, :], c='black', alpha=0.5)
 
     # Generate color mapping
     colors = (.5, .1, .3, 0.3)
@@ -137,7 +133,10 @@ def plot(cavity_npz, surf_func_npy=None):
         # Provide colors for Poly3DCollection
         colors = mappable.to_rgba(surf_func.flatten())
     # Generate list of vertices
-    vertices = [zip(cavity['vertices_' + str(i)][0, :], cavity['vertices_' + str(i)][1, :], cavity['vertices_' + str(i)][2, :]) for i in range(nElements)]
+    vertices = [
+        zip(cavity['vertices_' + str(i)][0, :], cavity['vertices_' + str(i)][1, :], cavity['vertices_' + str(i)][2, :])
+        for i in range(nElements)
+    ]
     elements = Poly3DCollection(vertices, facecolors=colors)
     ax.add_collection3d(elements)
     ax.set_axis_off()

--- a/tools/py2.x-getkw.py
+++ b/tools/py2.x-getkw.py
@@ -16,7 +16,7 @@
 # Known bugs: names with '-' mess things up...
 #
 
-import sys,os,inspect
+import sys, os, inspect
 import re, string
 from copy import deepcopy
 from types import *
@@ -27,43 +27,45 @@ from pyparsing import \
     commaSeparatedList, OneOrMore, Combine, srange, delimitedList, \
     downcaseTokens, line, lineno, StringEnd, Regex
 
-verbose=True
-strict=True
+verbose = True
+strict = True
+
 
 class Section:
     """Section class
 
     Placehoder for section objects
     """
-    def __init__(self,name,tag=None,req=False, callback=None):
-        self.name=name
-        self.sect={}
-        self.kw={}
-        self.tag=tag
-        self.req=req
-        self.isset=False
-        self.callback=callback
-        self.fullname=self.name
+
+    def __init__(self, name, tag=None, req=False, callback=None):
+        self.name = name
+        self.sect = {}
+        self.kw = {}
+        self.tag = tag
+        self.req = req
+        self.isset = False
+        self.callback = callback
+        self.fullname = self.name
         if tag != None:
-            self.fullname=self.fullname+'<'+self.tag+'>'
+            self.fullname = self.fullname + '<' + self.tag + '>'
 
     def __cmp__(self, other):
-        return cmp(self.name,other.name)
+        return cmp(self.name, other.name)
 
     def __getitem__(self, key):
         if key in self.sect:
-            foo=self.sect
+            foo = self.sect
         elif key in self.kw:
-            foo=self.kw
+            foo = self.kw
         else:
             return None
         return foo[key]
 
     def __setitem__(self, k, val):
         if isinstance(val, Section):
-            self.sect[k]=val
+            self.sect[k] = val
         elif isinstance(val, Keyword):
-            self.kw[k]=val
+            self.kw[k] = val
         else:
             raise TypeError('Not a Section or Keyword')
 
@@ -71,26 +73,25 @@ class Section:
         return self.__getitem__(k)
 
     def set(self, k, val):
-        self.__setitem__(k,val)
+        self.__setitem__(k, val)
 
     def _split_tag(self, key):
-        i=string.find(key, '<')
+        i = string.find(key, '<')
         if i == -1:
             return (key, None)
-        j=string.rfind(key, '>')
+        j = string.rfind(key, '>')
         if j == -1:
             raise KeyError('faulty tag spec')
-        return (key[0:i], key[i+1:j])
-
+        return (key[0:i], key[i + 1:j])
 
     def is_set(self, key=None):
         if key is None:
             return self.isset
         if key in self.kw:
             return self.kw[key].is_set()
-        (key, tag)=self._split_tag(key)
+        (key, tag) = self._split_tag(key)
         if key in self.sect:
-            sects=self.sect[key]
+            sects = self.sect[key]
             if tag in sects:
                 return sects[tag].is_set()
             else:
@@ -101,34 +102,34 @@ class Section:
         return self.req
 
     def add_sect(self, sect, set=False):
-        s=self.sect
+        s = self.sect
         if sect.name in s:
             if sect.tag in s[sect.name]:
                 print('Error: Section "%s" already defined!' % \
                         (sect.fullname))
                 sys.exit(1)
-            s[sect.name][sect.tag]=sect
+            s[sect.name][sect.tag] = sect
         else:
-            s[sect.name]={sect.tag : sect}
-        sect.isset=set
+            s[sect.name] = {sect.tag: sect}
+        sect.isset = set
 
     def add_kwkw(self, kw, set=False):
         if kw.name not in self.kw:
-            self.kw[kw.name]=kw
+            self.kw[kw.name] = kw
         else:
             print('Error: Keyword "%s.%s" already defined!' % \
                     (self.name, kw.name))
             sys.exit(1)
-        kw.isset=set
+        kw.isset = set
 
     def add_kw(self, name, typ, arg=None, req=False, set=False, callback=None):
         if name in self.kw:
             print('Error: Keyword "%s.%s" already defined!' % \
                     (self.name, kw.name))
             sys.exit(1)
-        kw=Keyword(name,typ,arg,req,callback)
-        kw.isset=set
-        self.kw[name]=kw
+        kw = Keyword(name, typ, arg, req, callback)
+        kw.isset = set
+        self.kw[name] = kw
 
     def fetch_kw(self, name):
         if name in self.kw:
@@ -136,52 +137,52 @@ class Section:
         return None
 
     def find_sect(self, path):
-        path=string.split(path, '.')
-        name=None
-        tag=None
-        s=self.sect
-        pname=''
+        path = string.split(path, '.')
+        name = None
+        tag = None
+        s = self.sect
+        pname = ''
         for i in path:
-            (name, tag)=self._split_tag(i)
-            pname=pname+i
+            (name, tag) = self._split_tag(i)
+            pname = pname + i
             try:
-                s=s[name]
+                s = s[name]
             except:
                 print('Invalid section: ', pname)
                 return None
             else:
-                pname=pname+'.'
+                pname = pname + '.'
         return s[tag]
 
     def get_keyword(self, path):
-        path=string.split(path, '.')
-        s=self.sect
-        k=self.kw
-        pname=''
+        path = string.split(path, '.')
+        s = self.sect
+        k = self.kw
+        pname = ''
         if len(path) == 1:
-            pname=path[0]
-            i=pname
+            pname = path[0]
+            i = pname
         else:
             for i in path[:-1]:
-                (name, tag)=self._split_tag(i)
-                pname=pname+i
+                (name, tag) = self._split_tag(i)
+                pname = pname + i
                 try:
-                    s=s[name]
+                    s = s[name]
                 except:
-                    str='Invalid section: ' + pname
+                    str = 'Invalid section: ' + pname
                     raise AttributeError(str)
                 else:
-                    pname=pname+'.'
-            pname=pname+path[-1:][0]
-            i=path[-1:][0]
-            k=s[tag].kw
+                    pname = pname + '.'
+            pname = pname + path[-1:][0]
+            i = path[-1:][0]
+            k = s[tag].kw
         if i in k:
             return k[i]
-        str='No such key: ' + pname
+        str = 'No such key: ' + pname
         raise AttributeError(str)
 
     def getkw(self, path):
-        kw=self.get_keyword(path)
+        kw = self.get_keyword(path)
         return kw.arg
 
     def setkw(self, name, arg):
@@ -191,7 +192,7 @@ class Section:
             print('Error: invalid kw: ', name)
 
     def fetch_sect(self, name):
-        (key, tag)=self._split_tag(name)
+        (key, tag) = self._split_tag(name)
         if key in self.sect:
             if tag in self.sect[key]:
                 return self.sect[key][tag]
@@ -208,9 +209,9 @@ class Section:
 
     def set_status(self, set):
         if set:
-            self.isset=True
+            self.isset = True
         else:
-            self.isset=False
+            self.isset = False
 
     def sanitize(self, templ):
         self.equalize(templ)
@@ -220,10 +221,10 @@ class Section:
     def equalize(self, templ):
         for i in templ.kw:
             if i not in self.kw:
-                self.kw[i]=deepcopy(templ.kw[i])
+                self.kw[i] = deepcopy(templ.kw[i])
         for i in templ.sect:
             if i not in self.sect:
-                self.sect[i]={None : deepcopy(templ.sect[i][None])}
+                self.sect[i] = {None: deepcopy(templ.sect[i][None])}
             for tag in self.sect[i]:
                 self.sect[i][tag].equalize(templ.sect[i][None])
 
@@ -231,7 +232,7 @@ class Section:
         if templ.callback is not None:
             templ.callback(self)
         for i in templ.kw:
-            cb=templ.kw[i]
+            cb = templ.kw[i]
             if cb.callback is not None:
                 cb.callback(self.kw[i])
         for i in templ.sect:
@@ -239,13 +240,14 @@ class Section:
                 self.sect[i][tag].run_callbacks(templ.sect[i][None])
 
 #verify!
-    def sanity_check(self,path=None):
-        dlm=''
+
+    def sanity_check(self, path=None):
+        dlm = ''
         if path is None:
-            path=''
+            path = ''
         else:
-            path=path+dlm+self.name
-            dlm='.'
+            path = path + dlm + self.name
+            dlm = '.'
         if self.req and not self.isset:
             print('>>> Required section not set: %s \n' % (path))
             sys.exit(0)
@@ -256,57 +258,57 @@ class Section:
                 j.sanity_check(path)
 
     #cross-validate against a template
-    def xvalidate(self,templ,path=None):
-        dlm=''
+    def xvalidate(self, templ, path=None):
+        dlm = ''
         if path is None:
-            path=''
+            path = ''
         else:
-            path=path+dlm+self.name
-            dlm='.'
+            path = path + dlm + self.name
+            dlm = '.'
         if templ.req and not self.isset:
             print('>>> Required section not set: %s \n' % path)
             sys.exit(1)
         for i in self.kw:
-            j=templ.fetch_kw(i)
+            j = templ.fetch_kw(i)
             if j is None:
-                print('>>> Invalid keyword: %s ' % (path+dlm+i))
+                print('>>> Invalid keyword: %s ' % (path + dlm + i))
                 sys.exit(1)
-            self.kw[i].xvalidate(j,path)
+            self.kw[i].xvalidate(j, path)
         for i in self.sect:
-            j=templ.fetch_sect(i)
+            j = templ.fetch_sect(i)
             if j is None:
-                print('>>> Invalid section: %s ' % (path+dlm+i))
+                print('>>> Invalid section: %s ' % (path + dlm + i))
                 sys.exit(1)
             for tag in self.sect[i]:
-                self.sect[i][tag].xvalidate(j,path)
+                self.sect[i][tag].xvalidate(j, path)
 
     def __str__(self):
-        nsect=0
+        nsect = 0
         for i in self.sect:
             for tag in self.sect[i]:
-                nsect=nsect+1
-        nkw=0
+                nsect = nsect + 1
+        nkw = 0
         for i in self.kw:
-            nkw=nkw+1
+            nkw = nkw + 1
 
-        s="SECT %s %d %s\n" % (self.name, nsect, self.isset)
+        s = "SECT %s %d %s\n" % (self.name, nsect, self.isset)
         if self.tag is not None:
-            s=s+"TAG T KW %d\n" % (nkw)
-            s=s+self.tag+'\n'
+            s = s + "TAG T KW %d\n" % (nkw)
+            s = s + self.tag + '\n'
         else:
-            s=s+"TAG F KW %d\n" % (nkw)
+            s = s + "TAG F KW %d\n" % (nkw)
 
         for i in self.kw:
-            s=s+str(self.kw[i])
+            s = s + str(self.kw[i])
         for i in self.sect:
             for tag in self.sect[i]:
-                s=s+str(self.sect[i][tag])
+                s = s + str(self.sect[i][tag])
         return s
 
     def check_key(self, key):
-        (name, tag)=self._split_tag(key)
+        (name, tag) = self._split_tag(key)
         try:
-            k=self.sect[name][tag]
+            k = self.sect[name][tag]
         except:
             print('No such key: ', key)
             sys.exit(1)
@@ -319,58 +321,58 @@ class Section:
 class Keyword:
     """Placehoder for keyword objects
     """
+
     def __init__(self, name, typ, arg=None, req=False, callback=None):
-        self.name=name
-        self.type=typ
-        self.req=req
-        self.nargs=None
-        self.arg=[]
-        self.is_array=False
-        self.callback=callback
+        self.name = name
+        self.type = typ
+        self.req = req
+        self.nargs = None
+        self.arg = []
+        self.is_array = False
+        self.callback = callback
 
         if re.search('_ARRAY', typ) or typ == 'DATA':
-            self.is_array=True
-            if arg is None: # unlimited arg length
-                self.nargs=-1
-            elif isinstance(arg,int): # number of elements in self.arg == arg
-                self.nargs=arg
-                arg=None
-            if isinstance(arg,tuple) or isinstance(arg,list):
-                self.nargs=len(arg)
+            self.is_array = True
+            if arg is None:  # unlimited arg length
+                self.nargs = -1
+            elif isinstance(arg, int):  # number of elements in self.arg == arg
+                self.nargs = arg
+                arg = None
+            if isinstance(arg, tuple) or isinstance(arg, list):
+                self.nargs = len(arg)
         else:
-            self.nargs=1
+            self.nargs = 1
         self.setkw(arg)
-        self.isset=False # reset the self.isset flag
+        self.isset = False  # reset the self.isset flag
 
     def __cmp__(self, other):
-        return cmp(self.name,other.name)
+        return cmp(self.name, other.name)
 
     def __getitem__(self, n):
         return self.arg[n]
 
     def __setitem__(self, n, arg):
-        if n > len(self.arg)-1:
+        if n > len(self.arg) - 1:
             raise IndexError
-        self.arg[n]=arg
+        self.arg[n] = arg
 
     def setkw(self, arg):
-        if arg is None: # init stage
+        if arg is None:  # init stage
             return
 
         if self.is_array and self.nargs > 0:
             if len(arg) != self.nargs:
-                print("keyword lenght mismatsh %s(%i): %i" % (self.name,
-                        self.nargs, len(arg)))
+                print("keyword lenght mismatsh %s(%i): %i" % (self.name, self.nargs, len(arg)))
                 sys.exit(1)
-            self.arg=arg
+            self.arg = arg
         else:
-            self.arg=[arg]
+            self.arg = [arg]
         try:
             self.typecheck()
         except TypeError:
             print('Invalid argument:', arg)
             sys.exit(1)
-        self.isset=True
+        self.isset = True
 
     def get(self):
         if self.is_array:
@@ -381,31 +383,31 @@ class Keyword:
     def set(self, val):
         self.setkw(val)
 
-    def sanity_check(self,path):
+    def sanity_check(self, path):
         if path is None:
-            path=self.name
+            path = self.name
         else:
-            path=path+'.'+self.name
-        if self.req  and not self.isset:
+            path = path + '.' + self.name
+        if self.req and not self.isset:
             print('>>> Required key not set: %s' % (path))
             if strict:
                 sys.exit(1)
 
-    def xvalidate(self,templ,path=None):
+    def xvalidate(self, templ, path=None):
         if path is None or path == '':
-            path=self.name
+            path = self.name
         else:
-            path=path+'.'+self.name
+            path = path + '.' + self.name
         if templ.req and not self.isset:
             print('>>> Required key not set: %s' % (path))
             sys.exit(1)
         if templ.type != self.type:
             if self.type == 'INT':
-                self.arg=list(map(float,self.arg))
-                self.type='DBL'
+                self.arg = list(map(float, self.arg))
+                self.type = 'DBL'
             elif self.type == 'INT_ARRAY':
-                self.arg=list(map(float,self.arg))
-                self.type='DBL_ARRAY'
+                self.arg = list(map(float, self.arg))
+                self.type = 'DBL_ARRAY'
             else:
                 print('>>> Invalid data type in: %s' % (path))
                 print(' -> wanted %s, got %s' % (templ.type, self.type))
@@ -425,19 +427,19 @@ class Keyword:
         if (self.type == 'INT' or self.type == 'INT_ARRAY'):
             for i in self.arg:
                 if not type(i) == IntType:
-                    print('getkw: Not an integer: ', self.name, '=',i)
+                    print('getkw: Not an integer: ', self.name, '=', i)
                     raise TypeError
         elif (self.type == 'DBL' or self.type == 'DBL_ARRAY'):
             for i in range(len(self.arg)):
                 if type(self.arg[i]) == IntType:
-                    self.arg[i]=float(self.arg[i])
+                    self.arg[i] = float(self.arg[i])
                 if not type(self.arg[i]) == FloatType:
                     print('getkw: Not a real: ', self.name, '=', self.arg[i])
                     raise TypeError
         elif (self.type == 'BOOL' or self.type == 'BOOL_ARRAY'):
             for i in self.arg:
                 if not type(i) == BooleanType:
-                    print('getkw: Not a bool: ', self.name, '=',i)
+                    print('getkw: Not a bool: ', self.name, '=', i)
                     raise TypeError
         elif self.type == 'STR' or self.type == 'STR_ARRAY':
             return True
@@ -461,32 +463,34 @@ class Keyword:
 
     def set_status(self, set):
         if set:
-            self.isset=True
+            self.isset = True
         else:
-            self.isset=False
+            self.isset = False
 
     def __str__(self):
-#        if self.type == 'STR':
-#            print 'foo', self.name, self.arg
+        #        if self.type == 'STR':
+        #            print 'foo', self.name, self.arg
         if (self.type == 'STR' or 'STR_ARRAY' or 'DATA') and \
                 (self.arg == '' or self.arg == None): # empty string
-            nargs=-1 # flags as empty for Fortran code
+            nargs = -1  # flags as empty for Fortran code
         else:
-            nargs=len(self.arg)
-            tmp=''
+            nargs = len(self.arg)
+            tmp = ''
             for i in self.arg:
-                tmp=tmp+str(i)+'\n'
-        s="%s %s %d %s\n" % (self.type, self.name, nargs, self.isset)
-        return s+tmp
+                tmp = tmp + str(i) + '\n'
+        s = "%s %s %d %s\n" % (self.type, self.name, nargs, self.isset)
+        return s + tmp
+
 
 class Getkw:
     """Unified interface to sections and keywords.
     Implements a path stack.
     """
+
     def __init__(self, top):
-        self.top=top
-        self.stack=[self.top]
-        self.cur=self.stack[0]
+        self.top = top
+        self.stack = [self.top]
+        self.cur = self.stack[0]
 
     def get_active_section(self):
         return self.cur
@@ -495,7 +499,7 @@ class Getkw:
         return self.cur.getkw(path)
 
     def get_keyword(self, path):
-        retur=self.cur.get_keyword(path)
+        retur = self.cur.get_keyword(path)
         return retur
 
     def setkw(self, path):
@@ -511,11 +515,11 @@ class Getkw:
         return self.cur.run_callbacks(templ)
 
     def push_sect(self, path):
-        k=self.cur.find_sect(path)
+        k = self.cur.find_sect(path)
         if k is None:
             return None
         self.stack.append(k)
-        self.cur=self.stack[-1]
+        self.cur = self.stack[-1]
         return self.cur
 
     def pop_sect(self):
@@ -523,187 +527,181 @@ class Getkw:
             del self.stack[-1]
         except:
             return None
-        self.cur=self.stack[-1]
+        self.cur = self.stack[-1]
         return self.cur
 
     def get_topsect(self):
         return self.top
+
 
 class GetkwParser:
     """Implements a class to do the actual parsing of input files and store
     the results in Sections and Keywords. The parseFile() method returns a
     Getkw object.
     """
-    bnf=None
-    caseless=False
-    yes=re.compile(r'(1|yes|true|on)$',re.I)
-    no=re.compile(r'(0|no|false|off)$',re.I)
+    bnf = None
+    caseless = False
+    yes = re.compile(r'(1|yes|true|on)$', re.I)
+    no = re.compile(r'(0|no|false|off)$', re.I)
 
-    def __init__(self,templ=None):
-        self.top=Section('toplevel')
-        self.stack=[self.top]
-        self.cur=self.stack[0]
-        self.templ=templ
-        self.strg=None
-        self.loc=None
+    def __init__(self, templ=None):
+        self.top = Section('toplevel')
+        self.stack = [self.top]
+        self.cur = self.stack[0]
+        self.templ = templ
+        self.strg = None
+        self.loc = None
         if templ is not None:
-            self.path=[self.templ]
+            self.path = [self.templ]
         else:
-            self.path=None
+            self.path = None
         if GetkwParser.bnf == None:
-            GetkwParser.bnf=self.getkw_bnf()
+            GetkwParser.bnf = self.getkw_bnf()
 #        self.parseString=self.bnf.parseString
 #        GetkwParser.bnf.setDebug(True)
 
     def set_caseless(self, arg):
         if arg is True:
-            self.caseless=True
+            self.caseless = True
         else:
-            self.caseless=False
+            self.caseless = False
 
-    def parseFile(self,fil):
+    def parseFile(self, fil):
         self.bnf.parseFile(fil)
         return Getkw(self.top)
 
-    def parseString(self,str):
+    def parseString(self, str):
         self.bnf.parseString(str)
         return Getkw(self.top)
 
-    def add_sect(self,s,l,t):
-        q=t.asList()
-        self.strg=s
-        self.loc=l
-        name=q[0]
-        tag=None
+    def add_sect(self, s, l, t):
+        q = t.asList()
+        self.strg = s
+        self.loc = l
+        name = q[0]
+        tag = None
         if len(q) > 1:
             if len(q[1]) > 0:
-                tag=q[1][0]
+                tag = q[1][0]
         if self.caseless:
-            name=name.lower()
-        k=Section(name, tag)
+            name = name.lower()
+        k = Section(name, tag)
         self.cur.add_sect(k, set=True)
         self.push_sect(k)
 
-    def push_sect(self,k):
+    def push_sect(self, k):
         self.stack.append(k)
-        self.cur=self.stack[-1]
+        self.cur = self.stack[-1]
         if self.templ is not None:
-            x=self.path[-1].fetch_sect(k.name)
+            x = self.path[-1].fetch_sect(k.name)
             if x is None:
-                print("Invalid section on line %d: \n%s" % (
-                        lineno(self.loc,self.strg), line(self.loc,self.strg)))
+                print("Invalid section on line %d: \n%s" % (lineno(self.loc, self.strg), line(self.loc, self.strg)))
                 sys.exit(1)
             self.path.append(x)
 
-    def pop_sect(self,s,l,t):
+    def pop_sect(self, s, l, t):
         if self.templ is not None:
             del self.path[-1]
         del self.stack[-1]
-        self.cur=self.stack[-1]
+        self.cur = self.stack[-1]
 
-    def store_key(self,s,l,t):
-        q=t.asList()
-        self.strg=s
-        self.loc=l
-        name=q[0]
-        arg=q[1]
+    def store_key(self, s, l, t):
+        q = t.asList()
+        self.strg = s
+        self.loc = l
+        name = q[0]
+        arg = q[1]
         if self.caseless:
-            name=name.lower()
+            name = name.lower()
         if self.templ is None:
-            argt=self.fixate_type(arg)
+            argt = self.fixate_type(arg)
         else:
-            k=self.path[-1].fetch_kw(name)
+            k = self.path[-1].fetch_kw(name)
             if k is None:
-                print("Unknown keyword '%s' line: %d" % (name,
-                        lineno(self.loc,self.strg)))
+                print("Unknown keyword '%s' line: %d" % (name, lineno(self.loc, self.strg)))
                 if strict:
                     sys.exit(1)
-                argt=None
+                argt = None
             else:
-                argt=self.check_type(arg,k.type)
-        k=Keyword(name,argt,arg)
-        self.cur.add_kwkw(k,set=True)
+                argt = self.check_type(arg, k.type)
+        k = Keyword(name, argt, arg)
+        self.cur.add_kwkw(k, set=True)
 
-    def store_vector(self,s,l,t):
-        q=t.asList()
-        self.strg=s
-        self.loc=l
-        name=q[0]
-        arg=q[1:]
+    def store_vector(self, s, l, t):
+        q = t.asList()
+        self.strg = s
+        self.loc = l
+        name = q[0]
+        arg = q[1:]
         if self.caseless:
-            name=name.lower()
+            name = name.lower()
         if self.templ is None:
-            argt=self.fixate_type(arg[0])
-            argt=argt+'_ARRAY'
+            argt = self.fixate_type(arg[0])
+            argt = argt + '_ARRAY'
         else:
-            k=self.path[-1].fetch_kw(name)
+            k = self.path[-1].fetch_kw(name)
             if k is None:
-                print("Unknown keyword '%s', line: %d" % (name,
-                        lineno(self.loc,self.strg)))
+                print("Unknown keyword '%s', line: %d" % (name, lineno(self.loc, self.strg)))
                 if strict:
                     sys.exit(1)
-                argt=None
+                argt = None
             else:
                 if k.nargs == -1:
                     pass
                 elif len(arg) != k.nargs:
                     print("Invalid number of elements for key '%s',\
-line: %d" % ( name, lineno(self.loc,self.strg)))
+line: %d" % (name, lineno(self.loc, self.strg)))
                     print("  -> %d required, %d given." % (k.nargs, len(arg)))
                     if strict:
                         sys.exit(1)
-                argt=self.check_type(arg,k.type)
-        k=Keyword(name,argt,arg)
-        self.cur.add_kwkw(k,set=True)
+                argt = self.check_type(arg, k.type)
+        k = Keyword(name, argt, arg)
+        self.cur.add_kwkw(k, set=True)
 
-    def store_data(self,s,l,t):
-        name=t[0]
-        self.strg=s
-        self.loc=l
+    def store_data(self, s, l, t):
+        name = t[0]
+        self.strg = s
+        self.loc = l
         if self.caseless:
-            name=name.lower()
-        dat=t[1].split('\n')
-        dat=dat[:-1] # remove empty element at the end
-        arg=[]
+            name = name.lower()
+        dat = t[1].split('\n')
+        dat = dat[:-1]  # remove empty element at the end
+        arg = []
         for i in dat:
             arg.append(i.strip())
-        k=Keyword(name,'DATA',arg)
-        self.cur.add_kwkw(k,set=True)
+        k = Keyword(name, 'DATA', arg)
+        self.cur.add_kwkw(k, set=True)
 
     def check_type(self, arg, argt):
         print("You hit a bug! Yipeee!")
         sys.exit(1)
         if (isinstance(arg, tuple) or isinstance(arg, list)):
-            argt=re.sub('_ARRAY', '', argt)
+            argt = re.sub('_ARRAY', '', argt)
             for i in arg:
                 self.check_type(i, argt)
 
         if argt == 'INT':
             if not ival.match(arg):
-                print('Invalid type on line %d: Not an int: \n -> %s' % (
-                        lineno(self.loc,self.strg), line(self.loc,
-                            self.strg).strip()))
+                print('Invalid type on line %d: Not an int: \n -> %s' % (lineno(self.loc, self.strg),
+                                                                         line(self.loc, self.strg).strip()))
                 sys.exit(1)
         elif argt == 'DBL':
             if not dval.match(arg):
-                print('Invalid type on line %d: Not a float: \n -> %s' % (
-                        lineno(self.loc,self.strg), line(self.loc,
-                            self.strg).strip()))
+                print('Invalid type on line %d: Not a float: \n -> %s' % (lineno(self.loc, self.strg),
+                                                                          line(self.loc, self.strg).strip()))
                 sys.exit(1)
         elif argt == 'BOOL':
             if not lval.match(arg):
-                print('Invalid type on line %d: Not a bool: \n -> %s' % (
-                        lineno(self.loc,self.strg), line(self.loc,
-                            self.strg).strip()))
+                print('Invalid type on line %d: Not a bool: \n -> %s' % (lineno(self.loc, self.strg),
+                                                                         line(self.loc, self.strg).strip()))
                 sys.exit(1)
         elif argt != 'STR':
-            print('Invalid type on line %d: Not a %s: \n -> %s' % (
-                    lineno(self.loc,self.strg), argt, line(self.loc,
-                        self.strg).strip()))
+            print('Invalid type on line %d: Not a %s: \n -> %s' % (lineno(self.loc, self.strg), argt,
+                                                                   line(self.loc, self.strg).strip()))
             sys.exit(1)
         return argt
 
-    def fixate_type(self,arg):
+    def fixate_type(self, arg):
         if isinstance(arg, bool):
             return 'BOOL'
         if isinstance(arg, int):
@@ -728,39 +726,39 @@ line: %d" % ( name, lineno(self.loc,self.strg)))
         return False
 
     def getkw_bnf(self):
-        sect_begin   = Literal("{").suppress()
-        sect_end   = Literal("}").suppress()
-        array_begin   = Literal("[").suppress()
-        array_end   = Literal("]").suppress()
-        tag_begin   = Literal("<").suppress()
-        tag_end   = Literal(">").suppress()
-        eql   = Literal("=").suppress()
+        sect_begin = Literal("{").suppress()
+        sect_end = Literal("}").suppress()
+        array_begin = Literal("[").suppress()
+        array_end = Literal("]").suppress()
+        tag_begin = Literal("<").suppress()
+        tag_end = Literal(">").suppress()
+        eql = Literal("=").suppress()
         dmark = Literal('$').suppress()
-        end_data=Literal('$end').suppress()
-        prtable = alphanums+r'!$%&*+-./<>?@^_|~'
-        ival=Regex('[-]?\d+')
-        dval=Regex('-?\d+\.\d*([eE]?[+-]?\d+)?')
-        lval=Regex('([Yy]es|[Nn]o|[Tt]rue|[Ff]alse|[Oo]n|[Oo]ff)')
+        end_data = Literal('$end').suppress()
+        prtable = alphanums + r'!$%&*+-./<>?@^_|~'
+        ival = Regex('[-]?\d+')
+        dval = Regex('-?\d+\.\d*([eE]?[+-]?\d+)?')
+        lval = Regex('([Yy]es|[Nn]o|[Tt]rue|[Ff]alse|[Oo]n|[Oo]ff)')
 
         # Helper definitions
 
         kstr= quotedString.setParseAction(removeQuotes) ^ \
                 dval ^ ival ^ lval ^ Word(prtable)
-        name = Word(alphas+"_",alphanums+"_")
+        name = Word(alphas + "_", alphanums + "_")
         vec=array_begin+delimitedList(dval ^ ival ^ lval ^ Word(prtable) ^ \
                 Literal("\n").suppress() ^ \
                 quotedString.setParseAction(removeQuotes))+array_end
-        sect=name+sect_begin
-        tag_sect=name+Group(tag_begin+name+tag_end)+sect_begin
+        sect = name + sect_begin
+        tag_sect = name + Group(tag_begin + name + tag_end) + sect_begin
 
         # Grammar
         keyword = name + eql + kstr
         vector = name + eql + vec
-        data=Combine(dmark+name)+SkipTo(end_data)+end_data
-        section=Forward()
-        sect_def=(sect | tag_sect ) #| vec_sect)
-        input=section | data | vector | keyword
-        section << sect_def+ZeroOrMore(input) + sect_end
+        data = Combine(dmark + name) + SkipTo(end_data) + end_data
+        section = Forward()
+        sect_def = (sect | tag_sect)  #| vec_sect)
+        input = section | data | vector | keyword
+        section << sect_def + ZeroOrMore(input) + sect_end
 
         # Parsing actions
         ival.setParseAction(self.conv_ival)
@@ -773,20 +771,21 @@ line: %d" % ( name, lineno(self.loc,self.strg)))
         tag_sect.setParseAction(self.add_sect)
         sect_end.setParseAction(self.pop_sect)
 
-        bnf=ZeroOrMore(input) + StringEnd().setFailAction(parse_error)
+        bnf = ZeroOrMore(input) + StringEnd().setFailAction(parse_error)
         bnf.ignore(pythonStyleComment)
         return bnf
 
-def parse_error(s,t,d,err):
-    print("Parse error, line %d: %s" %  ( lineno(err.loc,err.pstr),
-            line(err.loc,err.pstr)))
+
+def parse_error(s, t, d, err):
+    print("Parse error, line %d: %s" % (lineno(err.loc, err.pstr), line(err.loc, err.pstr)))
     sys.exit(1)
 
 ######## Convenience routines for callbacks ########
 
-def check_opt(sect,key):
+
+def check_opt(sect, key):
     try:
-        k=sect[key]
+        k = sect[key]
     except:
         print('You have a typo in the code for key', key)
         sys.exit(1)
@@ -795,8 +794,9 @@ def check_opt(sect,key):
             return True
     return False
 
+
 def check_required(list, sect):
-    err="Error: Required option '%s' not set in section '%s%s'!"
+    err = "Error: Required option '%s' not set in section '%s%s'!"
     for i in list:
         if not check_opt(sect, i):
             if sect.name == sect.tag or sect.tag is None:
@@ -805,8 +805,9 @@ def check_required(list, sect):
                 print(err % (i, sect.name, '<' + sect.tag + '>'))
             sys.exit(1)
 
+
 def check_ignored(list, sect):
-    warn="Warning: The '%s' option will be ignored in section '%s%s'."
+    warn = "Warning: The '%s' option will be ignored in section '%s%s'."
     for i in list:
         if check_opt(sect, i):
             if sect.name == sect.tag:
@@ -816,18 +817,20 @@ def check_ignored(list, sect):
 
 ####################################################
 
-def test( strng ):
+
+def test(strng):
     bnf = GetkwParser()
     try:
-        tokens=bnf.parseString(strng)
+        tokens = bnf.parseString(strng)
     except ParseException as err:
         print(err.line)
-        print(" "*(err.column-1) + "^")
+        print(" " * (err.column - 1) + "^")
         print(err)
     return tokens
 
+
 if __name__ == '__main__':
-    teststr="""
+    teststr = """
 title = foo
 string="fooo bar"
 
@@ -880,4 +883,3 @@ raboof {
     print(ini.top)
 #    foo=ini.get_keyword('raboof.foo')
 #    print dir(foo)
-

--- a/tools/py3.x-getkw.py
+++ b/tools/py3.x-getkw.py
@@ -16,7 +16,7 @@
 # Known bugs: names with '-' mess things up...
 #
 
-import sys,os,inspect
+import sys, os, inspect
 import re, string
 from copy import deepcopy
 from pyparsing import \
@@ -26,43 +26,45 @@ from pyparsing import \
     commaSeparatedList, OneOrMore, Combine, srange, delimitedList, \
     downcaseTokens, line, lineno, StringEnd, Regex
 
-verbose=True
-strict=True
+verbose = True
+strict = True
+
 
 class Section:
     """Section class
 
     Placehoder for section objects
     """
-    def __init__(self,name,tag=None,req=False, callback=None):
-        self.name=name
-        self.sect={}
-        self.kw={}
-        self.tag=tag
-        self.req=req
-        self.isset=False
-        self.callback=callback
-        self.fullname=self.name
+
+    def __init__(self, name, tag=None, req=False, callback=None):
+        self.name = name
+        self.sect = {}
+        self.kw = {}
+        self.tag = tag
+        self.req = req
+        self.isset = False
+        self.callback = callback
+        self.fullname = self.name
         if tag != None:
-            self.fullname=self.fullname+'<'+self.tag+'>'
+            self.fullname = self.fullname + '<' + self.tag + '>'
 
     def __cmp__(self, other):
-        return cmp(self.name,other.name)
+        return cmp(self.name, other.name)
 
     def __getitem__(self, key):
         if key in self.sect:
-            foo=self.sect
+            foo = self.sect
         elif key in self.kw:
-            foo=self.kw
+            foo = self.kw
         else:
             return None
         return foo[key]
 
     def __setitem__(self, k, val):
         if isinstance(val, Section):
-            self.sect[k]=val
+            self.sect[k] = val
         elif isinstance(val, Keyword):
-            self.kw[k]=val
+            self.kw[k] = val
         else:
             raise TypeError('Not a Section or Keyword')
 
@@ -70,26 +72,25 @@ class Section:
         return self.__getitem__(k)
 
     def set(self, k, val):
-        self.__setitem__(k,val)
+        self.__setitem__(k, val)
 
     def _split_tag(self, key):
-        i=key.find('<')
+        i = key.find('<')
         if i == -1:
             return (key, None)
-        j=key.rfind('>')
+        j = key.rfind('>')
         if j == -1:
             raise KeyError('faulty tag spec')
-        return (key[0:i], key[i+1:j])
-
+        return (key[0:i], key[i + 1:j])
 
     def is_set(self, key=None):
         if key is None:
             return self.isset
         if key in self.kw:
             return self.kw[key].is_set()
-        (key, tag)=self._split_tag(key)
+        (key, tag) = self._split_tag(key)
         if key in self.sect:
-            sects=self.sect[key]
+            sects = self.sect[key]
             if tag in sects:
                 return sects[tag].is_set()
             else:
@@ -100,34 +101,34 @@ class Section:
         return self.req
 
     def add_sect(self, sect, set=False):
-        s=self.sect
+        s = self.sect
         if sect.name in s:
             if sect.tag in s[sect.name]:
                 print('Error: Section "%s" already defined!' % \
                         (sect.fullname))
                 sys.exit(1)
-            s[sect.name][sect.tag]=sect
+            s[sect.name][sect.tag] = sect
         else:
-            s[sect.name]={sect.tag : sect}
-        sect.isset=set
+            s[sect.name] = {sect.tag: sect}
+        sect.isset = set
 
     def add_kwkw(self, kw, set=False):
         if kw.name not in self.kw:
-            self.kw[kw.name]=kw
+            self.kw[kw.name] = kw
         else:
             print('Error: Keyword "%s.%s" already defined!' % \
                     (self.name, kw.name))
             sys.exit(1)
-        kw.isset=set
+        kw.isset = set
 
     def add_kw(self, name, typ, arg=None, req=False, set=False, callback=None):
         if name in self.kw:
             print('Error: Keyword "%s.%s" already defined!' % \
                     (self.name, kw.name))
             sys.exit(1)
-        kw=Keyword(name,typ,arg,req,callback)
-        kw.isset=set
-        self.kw[name]=kw
+        kw = Keyword(name, typ, arg, req, callback)
+        kw.isset = set
+        self.kw[name] = kw
 
     def fetch_kw(self, name):
         if name in self.kw:
@@ -135,52 +136,52 @@ class Section:
         return None
 
     def find_sect(self, path):
-        path=string.split(path, '.')
-        name=None
-        tag=None
-        s=self.sect
-        pname=''
+        path = string.split(path, '.')
+        name = None
+        tag = None
+        s = self.sect
+        pname = ''
         for i in path:
-            (name, tag)=self._split_tag(i)
-            pname=pname+i
+            (name, tag) = self._split_tag(i)
+            pname = pname + i
             try:
-                s=s[name]
+                s = s[name]
             except:
                 print('Invalid section: ', pname)
                 return None
             else:
-                pname=pname+'.'
+                pname = pname + '.'
         return s[tag]
 
     def get_keyword(self, path):
-        path=string.split(path, '.')
-        s=self.sect
-        k=self.kw
-        pname=''
+        path = string.split(path, '.')
+        s = self.sect
+        k = self.kw
+        pname = ''
         if len(path) == 1:
-            pname=path[0]
-            i=pname
+            pname = path[0]
+            i = pname
         else:
             for i in path[:-1]:
-                (name, tag)=self._split_tag(i)
-                pname=pname+i
+                (name, tag) = self._split_tag(i)
+                pname = pname + i
                 try:
-                    s=s[name]
+                    s = s[name]
                 except:
-                    str='Invalid section: ' + pname
+                    str = 'Invalid section: ' + pname
                     raise AttributeError(str)
                 else:
-                    pname=pname+'.'
-            pname=pname+path[-1:][0]
-            i=path[-1:][0]
-            k=s[tag].kw
+                    pname = pname + '.'
+            pname = pname + path[-1:][0]
+            i = path[-1:][0]
+            k = s[tag].kw
         if i in k:
             return k[i]
-        str='No such key: ' + pname
+        str = 'No such key: ' + pname
         raise AttributeError(str)
 
     def getkw(self, path):
-        kw=self.get_keyword(path)
+        kw = self.get_keyword(path)
         return kw.arg
 
     def setkw(self, name, arg):
@@ -190,7 +191,7 @@ class Section:
             print('Error: invalid kw: ', name)
 
     def fetch_sect(self, name):
-        (key, tag)=self._split_tag(name)
+        (key, tag) = self._split_tag(name)
         if key in self.sect:
             if tag in self.sect[key]:
                 return self.sect[key][tag]
@@ -207,9 +208,9 @@ class Section:
 
     def set_status(self, set):
         if set:
-            self.isset=True
+            self.isset = True
         else:
-            self.isset=False
+            self.isset = False
 
     def sanitize(self, templ):
         self.equalize(templ)
@@ -219,10 +220,10 @@ class Section:
     def equalize(self, templ):
         for i in templ.kw:
             if i not in self.kw:
-                self.kw[i]=deepcopy(templ.kw[i])
+                self.kw[i] = deepcopy(templ.kw[i])
         for i in templ.sect:
             if i not in self.sect:
-                self.sect[i]={None : deepcopy(templ.sect[i][None])}
+                self.sect[i] = {None: deepcopy(templ.sect[i][None])}
             for tag in self.sect[i]:
                 self.sect[i][tag].equalize(templ.sect[i][None])
 
@@ -230,7 +231,7 @@ class Section:
         if templ.callback is not None:
             templ.callback(self)
         for i in templ.kw:
-            cb=templ.kw[i]
+            cb = templ.kw[i]
             if cb.callback is not None:
                 cb.callback(self.kw[i])
         for i in templ.sect:
@@ -238,13 +239,14 @@ class Section:
                 self.sect[i][tag].run_callbacks(templ.sect[i][None])
 
 #verify!
-    def sanity_check(self,path=None):
-        dlm=''
+
+    def sanity_check(self, path=None):
+        dlm = ''
         if path is None:
-            path=''
+            path = ''
         else:
-            path=path+dlm+self.name
-            dlm='.'
+            path = path + dlm + self.name
+            dlm = '.'
         if self.req and not self.isset:
             print('>>> Required section not set: %s \n' % (path))
             sys.exit(0)
@@ -255,57 +257,57 @@ class Section:
                 j.sanity_check(path)
 
     #cross-validate against a template
-    def xvalidate(self,templ,path=None):
-        dlm=''
+    def xvalidate(self, templ, path=None):
+        dlm = ''
         if path is None:
-            path=''
+            path = ''
         else:
-            path=path+dlm+self.name
-            dlm='.'
+            path = path + dlm + self.name
+            dlm = '.'
         if templ.req and not self.isset:
             print('>>> Required section not set: %s \n' % path)
             sys.exit(1)
         for i in self.kw:
-            j=templ.fetch_kw(i)
+            j = templ.fetch_kw(i)
             if j is None:
-                print('>>> Invalid keyword: %s ' % (path+dlm+i))
+                print('>>> Invalid keyword: %s ' % (path + dlm + i))
                 sys.exit(1)
-            self.kw[i].xvalidate(j,path)
+            self.kw[i].xvalidate(j, path)
         for i in self.sect:
-            j=templ.fetch_sect(i)
+            j = templ.fetch_sect(i)
             if j is None:
-                print('>>> Invalid section: %s ' % (path+dlm+i))
+                print('>>> Invalid section: %s ' % (path + dlm + i))
                 sys.exit(1)
             for tag in self.sect[i]:
-                self.sect[i][tag].xvalidate(j,path)
+                self.sect[i][tag].xvalidate(j, path)
 
     def __str__(self):
-        nsect=0
+        nsect = 0
         for i in self.sect:
             for tag in self.sect[i]:
-                nsect=nsect+1
-        nkw=0
+                nsect = nsect + 1
+        nkw = 0
         for i in self.kw:
-            nkw=nkw+1
+            nkw = nkw + 1
 
-        s="SECT %s %d %s\n" % (self.name, nsect, self.isset)
+        s = "SECT %s %d %s\n" % (self.name, nsect, self.isset)
         if self.tag is not None:
-            s=s+"TAG T KW %d\n" % (nkw)
-            s=s+self.tag+'\n'
+            s = s + "TAG T KW %d\n" % (nkw)
+            s = s + self.tag + '\n'
         else:
-            s=s+"TAG F KW %d\n" % (nkw)
+            s = s + "TAG F KW %d\n" % (nkw)
 
         for i in self.kw:
-            s=s+str(self.kw[i])
+            s = s + str(self.kw[i])
         for i in self.sect:
             for tag in self.sect[i]:
-                s=s+str(self.sect[i][tag])
+                s = s + str(self.sect[i][tag])
         return s
 
     def check_key(self, key):
-        (name, tag)=self._split_tag(key)
+        (name, tag) = self._split_tag(key)
         try:
-            k=self.sect[name][tag]
+            k = self.sect[name][tag]
         except:
             print('No such key: ', key)
             sys.exit(1)
@@ -318,58 +320,58 @@ class Section:
 class Keyword:
     """Placehoder for keyword objects
     """
+
     def __init__(self, name, typ, arg=None, req=False, callback=None):
-        self.name=name
-        self.type=typ
-        self.req=req
-        self.nargs=None
-        self.arg=[]
-        self.is_array=False
-        self.callback=callback
+        self.name = name
+        self.type = typ
+        self.req = req
+        self.nargs = None
+        self.arg = []
+        self.is_array = False
+        self.callback = callback
 
         if re.search('_ARRAY', typ) or typ == 'DATA':
-            self.is_array=True
-            if arg is None: # unlimited arg length
-                self.nargs=-1
-            elif isinstance(arg,int): # number of elements in self.arg == arg
-                self.nargs=arg
-                arg=None
-            if isinstance(arg,tuple) or isinstance(arg,list):
-                self.nargs=len(arg)
+            self.is_array = True
+            if arg is None:  # unlimited arg length
+                self.nargs = -1
+            elif isinstance(arg, int):  # number of elements in self.arg == arg
+                self.nargs = arg
+                arg = None
+            if isinstance(arg, tuple) or isinstance(arg, list):
+                self.nargs = len(arg)
         else:
-            self.nargs=1
+            self.nargs = 1
         self.setkw(arg)
-        self.isset=False # reset the self.isset flag
+        self.isset = False  # reset the self.isset flag
 
     def __cmp__(self, other):
-        return cmp(self.name,other.name)
+        return cmp(self.name, other.name)
 
     def __getitem__(self, n):
         return self.arg[n]
 
     def __setitem__(self, n, arg):
-        if n > len(self.arg)-1:
+        if n > len(self.arg) - 1:
             raise IndexError
-        self.arg[n]=arg
+        self.arg[n] = arg
 
     def setkw(self, arg):
-        if arg is None: # init stage
+        if arg is None:  # init stage
             return
 
         if self.is_array and self.nargs > 0:
             if len(arg) != self.nargs:
-                print("keyword lenght mismatsh %s(%i): %i" % (self.name,
-                        self.nargs, len(arg)))
+                print("keyword lenght mismatsh %s(%i): %i" % (self.name, self.nargs, len(arg)))
                 sys.exit(1)
-            self.arg=arg
+            self.arg = arg
         else:
-            self.arg=[arg]
+            self.arg = [arg]
         try:
             self.typecheck()
         except TypeError:
             print('Invalid argument:', arg)
             sys.exit(1)
-        self.isset=True
+        self.isset = True
 
     def get(self):
         if self.is_array:
@@ -380,31 +382,31 @@ class Keyword:
     def set(self, val):
         self.setkw(val)
 
-    def sanity_check(self,path):
+    def sanity_check(self, path):
         if path is None:
-            path=self.name
+            path = self.name
         else:
-            path=path+'.'+self.name
-        if self.req  and not self.isset:
+            path = path + '.' + self.name
+        if self.req and not self.isset:
             print('>>> Required key not set: %s' % (path))
             if strict:
                 sys.exit(1)
 
-    def xvalidate(self,templ,path=None):
+    def xvalidate(self, templ, path=None):
         if path is None or path == '':
-            path=self.name
+            path = self.name
         else:
-            path=path+'.'+self.name
+            path = path + '.' + self.name
         if templ.req and not self.isset:
             print('>>> Required key not set: %s' % (path))
             sys.exit(1)
         if templ.type != self.type:
             if self.type == 'INT':
-                self.arg=list(map(float,self.arg))
-                self.type='DBL'
+                self.arg = list(map(float, self.arg))
+                self.type = 'DBL'
             elif self.type == 'INT_ARRAY':
-                self.arg=list(map(float,self.arg))
-                self.type='DBL_ARRAY'
+                self.arg = list(map(float, self.arg))
+                self.type = 'DBL_ARRAY'
             else:
                 print('>>> Invalid data type in: %s' % (path))
                 print(' -> wanted %s, got %s' % (templ.type, self.type))
@@ -424,19 +426,19 @@ class Keyword:
         if (self.type == 'INT' or self.type == 'INT_ARRAY'):
             for i in self.arg:
                 if not type(i) == int:
-                    print('getkw: Not an integer: ', self.name, '=',i)
+                    print('getkw: Not an integer: ', self.name, '=', i)
                     raise TypeError
         elif (self.type == 'DBL' or self.type == 'DBL_ARRAY'):
             for i in range(len(self.arg)):
                 if type(self.arg[i]) == int:
-                    self.arg[i]=float(self.arg[i])
+                    self.arg[i] = float(self.arg[i])
                 if not type(self.arg[i]) == float:
                     print('getkw: Not a real: ', self.name, '=', self.arg[i])
                     raise TypeError
         elif (self.type == 'BOOL' or self.type == 'BOOL_ARRAY'):
             for i in self.arg:
                 if not type(i) == bool:
-                    print('getkw: Not a bool: ', self.name, '=',i)
+                    print('getkw: Not a bool: ', self.name, '=', i)
                     raise TypeError
         elif self.type == 'STR' or self.type == 'STR_ARRAY':
             return True
@@ -460,32 +462,34 @@ class Keyword:
 
     def set_status(self, set):
         if set:
-            self.isset=True
+            self.isset = True
         else:
-            self.isset=False
+            self.isset = False
 
     def __str__(self):
-#        if self.type == 'STR':
-#            print 'foo', self.name, self.arg
+        #        if self.type == 'STR':
+        #            print 'foo', self.name, self.arg
         if (self.type == 'STR' or 'STR_ARRAY' or 'DATA') and \
                 (self.arg == '' or self.arg == None): # empty string
-            nargs=-1 # flags as empty for Fortran code
+            nargs = -1  # flags as empty for Fortran code
         else:
-            nargs=len(self.arg)
-            tmp=''
+            nargs = len(self.arg)
+            tmp = ''
             for i in self.arg:
-                tmp=tmp+str(i)+'\n'
-        s="%s %s %d %s\n" % (self.type, self.name, nargs, self.isset)
-        return s+tmp
+                tmp = tmp + str(i) + '\n'
+        s = "%s %s %d %s\n" % (self.type, self.name, nargs, self.isset)
+        return s + tmp
+
 
 class Getkw:
     """Unified interface to sections and keywords.
     Implements a path stack.
     """
+
     def __init__(self, top):
-        self.top=top
-        self.stack=[self.top]
-        self.cur=self.stack[0]
+        self.top = top
+        self.stack = [self.top]
+        self.cur = self.stack[0]
 
     def get_active_section(self):
         return self.cur
@@ -494,7 +498,7 @@ class Getkw:
         return self.cur.getkw(path)
 
     def get_keyword(self, path):
-        retur=self.cur.get_keyword(path)
+        retur = self.cur.get_keyword(path)
         return retur
 
     def setkw(self, path):
@@ -510,11 +514,11 @@ class Getkw:
         return self.cur.run_callbacks(templ)
 
     def push_sect(self, path):
-        k=self.cur.find_sect(path)
+        k = self.cur.find_sect(path)
         if k is None:
             return None
         self.stack.append(k)
-        self.cur=self.stack[-1]
+        self.cur = self.stack[-1]
         return self.cur
 
     def pop_sect(self):
@@ -522,187 +526,181 @@ class Getkw:
             del self.stack[-1]
         except:
             return None
-        self.cur=self.stack[-1]
+        self.cur = self.stack[-1]
         return self.cur
 
     def get_topsect(self):
         return self.top
+
 
 class GetkwParser:
     """Implements a class to do the actual parsing of input files and store
     the results in Sections and Keywords. The parseFile() method returns a
     Getkw object.
     """
-    bnf=None
-    caseless=False
-    yes=re.compile(r'(1|yes|true|on)$',re.I)
-    no=re.compile(r'(0|no|false|off)$',re.I)
+    bnf = None
+    caseless = False
+    yes = re.compile(r'(1|yes|true|on)$', re.I)
+    no = re.compile(r'(0|no|false|off)$', re.I)
 
-    def __init__(self,templ=None):
-        self.top=Section('toplevel')
-        self.stack=[self.top]
-        self.cur=self.stack[0]
-        self.templ=templ
-        self.strg=None
-        self.loc=None
+    def __init__(self, templ=None):
+        self.top = Section('toplevel')
+        self.stack = [self.top]
+        self.cur = self.stack[0]
+        self.templ = templ
+        self.strg = None
+        self.loc = None
         if templ is not None:
-            self.path=[self.templ]
+            self.path = [self.templ]
         else:
-            self.path=None
+            self.path = None
         if GetkwParser.bnf == None:
-            GetkwParser.bnf=self.getkw_bnf()
+            GetkwParser.bnf = self.getkw_bnf()
 #        self.parseString=self.bnf.parseString
 #        GetkwParser.bnf.setDebug(True)
 
     def set_caseless(self, arg):
         if arg is True:
-            self.caseless=True
+            self.caseless = True
         else:
-            self.caseless=False
+            self.caseless = False
 
-    def parseFile(self,fil):
+    def parseFile(self, fil):
         self.bnf.parseFile(fil)
         return Getkw(self.top)
 
-    def parseString(self,str):
+    def parseString(self, str):
         self.bnf.parseString(str)
         return Getkw(self.top)
 
-    def add_sect(self,s,l,t):
-        q=t.asList()
-        self.strg=s
-        self.loc=l
-        name=q[0]
-        tag=None
+    def add_sect(self, s, l, t):
+        q = t.asList()
+        self.strg = s
+        self.loc = l
+        name = q[0]
+        tag = None
         if len(q) > 1:
             if len(q[1]) > 0:
-                tag=q[1][0]
+                tag = q[1][0]
         if self.caseless:
-            name=name.lower()
-        k=Section(name, tag)
+            name = name.lower()
+        k = Section(name, tag)
         self.cur.add_sect(k, set=True)
         self.push_sect(k)
 
-    def push_sect(self,k):
+    def push_sect(self, k):
         self.stack.append(k)
-        self.cur=self.stack[-1]
+        self.cur = self.stack[-1]
         if self.templ is not None:
-            x=self.path[-1].fetch_sect(k.name)
+            x = self.path[-1].fetch_sect(k.name)
             if x is None:
-                print("Invalid section on line %d: \n%s" % (
-                        lineno(self.loc,self.strg), line(self.loc,self.strg)))
+                print("Invalid section on line %d: \n%s" % (lineno(self.loc, self.strg), line(self.loc, self.strg)))
                 sys.exit(1)
             self.path.append(x)
 
-    def pop_sect(self,s,l,t):
+    def pop_sect(self, s, l, t):
         if self.templ is not None:
             del self.path[-1]
         del self.stack[-1]
-        self.cur=self.stack[-1]
+        self.cur = self.stack[-1]
 
-    def store_key(self,s,l,t):
-        q=t.asList()
-        self.strg=s
-        self.loc=l
-        name=q[0]
-        arg=q[1]
+    def store_key(self, s, l, t):
+        q = t.asList()
+        self.strg = s
+        self.loc = l
+        name = q[0]
+        arg = q[1]
         if self.caseless:
-            name=name.lower()
+            name = name.lower()
         if self.templ is None:
-            argt=self.fixate_type(arg)
+            argt = self.fixate_type(arg)
         else:
-            k=self.path[-1].fetch_kw(name)
+            k = self.path[-1].fetch_kw(name)
             if k is None:
-                print("Unknown keyword '%s' line: %d" % (name,
-                        lineno(self.loc,self.strg)))
+                print("Unknown keyword '%s' line: %d" % (name, lineno(self.loc, self.strg)))
                 if strict:
                     sys.exit(1)
-                argt=None
+                argt = None
             else:
-                argt=self.check_type(arg,k.type)
-        k=Keyword(name,argt,arg)
-        self.cur.add_kwkw(k,set=True)
+                argt = self.check_type(arg, k.type)
+        k = Keyword(name, argt, arg)
+        self.cur.add_kwkw(k, set=True)
 
-    def store_vector(self,s,l,t):
-        q=t.asList()
-        self.strg=s
-        self.loc=l
-        name=q[0]
-        arg=q[1:]
+    def store_vector(self, s, l, t):
+        q = t.asList()
+        self.strg = s
+        self.loc = l
+        name = q[0]
+        arg = q[1:]
         if self.caseless:
-            name=name.lower()
+            name = name.lower()
         if self.templ is None:
-            argt=self.fixate_type(arg[0])
-            argt=argt+'_ARRAY'
+            argt = self.fixate_type(arg[0])
+            argt = argt + '_ARRAY'
         else:
-            k=self.path[-1].fetch_kw(name)
+            k = self.path[-1].fetch_kw(name)
             if k is None:
-                print("Unknown keyword '%s', line: %d" % (name,
-                        lineno(self.loc,self.strg)))
+                print("Unknown keyword '%s', line: %d" % (name, lineno(self.loc, self.strg)))
                 if strict:
                     sys.exit(1)
-                argt=None
+                argt = None
             else:
                 if k.nargs == -1:
                     pass
                 elif len(arg) != k.nargs:
                     print("Invalid number of elements for key '%s',\
-line: %d" % ( name, lineno(self.loc,self.strg)))
+line: %d" % (name, lineno(self.loc, self.strg)))
                     print("  -> %d required, %d given." % (k.nargs, len(arg)))
                     if strict:
                         sys.exit(1)
-                argt=self.check_type(arg,k.type)
-        k=Keyword(name,argt,arg)
-        self.cur.add_kwkw(k,set=True)
+                argt = self.check_type(arg, k.type)
+        k = Keyword(name, argt, arg)
+        self.cur.add_kwkw(k, set=True)
 
-    def store_data(self,s,l,t):
-        name=t[0]
-        self.strg=s
-        self.loc=l
+    def store_data(self, s, l, t):
+        name = t[0]
+        self.strg = s
+        self.loc = l
         if self.caseless:
-            name=name.lower()
-        dat=t[1].split('\n')
-        dat=dat[:-1] # remove empty element at the end
-        arg=[]
+            name = name.lower()
+        dat = t[1].split('\n')
+        dat = dat[:-1]  # remove empty element at the end
+        arg = []
         for i in dat:
             arg.append(i.strip())
-        k=Keyword(name,'DATA',arg)
-        self.cur.add_kwkw(k,set=True)
+        k = Keyword(name, 'DATA', arg)
+        self.cur.add_kwkw(k, set=True)
 
     def check_type(self, arg, argt):
         print("You hit a bug! Yipeee!")
         sys.exit(1)
         if (isinstance(arg, tuple) or isinstance(arg, list)):
-            argt=re.sub('_ARRAY', '', argt)
+            argt = re.sub('_ARRAY', '', argt)
             for i in arg:
                 self.check_type(i, argt)
 
         if argt == 'INT':
             if not ival.match(arg):
-                print('Invalid type on line %d: Not an int: \n -> %s' % (
-                        lineno(self.loc,self.strg), line(self.loc,
-                            self.strg).strip()))
+                print('Invalid type on line %d: Not an int: \n -> %s' % (lineno(self.loc, self.strg),
+                                                                         line(self.loc, self.strg).strip()))
                 sys.exit(1)
         elif argt == 'DBL':
             if not dval.match(arg):
-                print('Invalid type on line %d: Not a float: \n -> %s' % (
-                        lineno(self.loc,self.strg), line(self.loc,
-                            self.strg).strip()))
+                print('Invalid type on line %d: Not a float: \n -> %s' % (lineno(self.loc, self.strg),
+                                                                          line(self.loc, self.strg).strip()))
                 sys.exit(1)
         elif argt == 'BOOL':
             if not lval.match(arg):
-                print('Invalid type on line %d: Not a bool: \n -> %s' % (
-                        lineno(self.loc,self.strg), line(self.loc,
-                            self.strg).strip()))
+                print('Invalid type on line %d: Not a bool: \n -> %s' % (lineno(self.loc, self.strg),
+                                                                         line(self.loc, self.strg).strip()))
                 sys.exit(1)
         elif argt != 'STR':
-            print('Invalid type on line %d: Not a %s: \n -> %s' % (
-                    lineno(self.loc,self.strg), argt, line(self.loc,
-                        self.strg).strip()))
+            print('Invalid type on line %d: Not a %s: \n -> %s' % (lineno(self.loc, self.strg), argt,
+                                                                   line(self.loc, self.strg).strip()))
             sys.exit(1)
         return argt
 
-    def fixate_type(self,arg):
+    def fixate_type(self, arg):
         if isinstance(arg, bool):
             return 'BOOL'
         if isinstance(arg, int):
@@ -727,39 +725,39 @@ line: %d" % ( name, lineno(self.loc,self.strg)))
         return False
 
     def getkw_bnf(self):
-        sect_begin   = Literal("{").suppress()
-        sect_end   = Literal("}").suppress()
-        array_begin   = Literal("[").suppress()
-        array_end   = Literal("]").suppress()
-        tag_begin   = Literal("<").suppress()
-        tag_end   = Literal(">").suppress()
-        eql   = Literal("=").suppress()
+        sect_begin = Literal("{").suppress()
+        sect_end = Literal("}").suppress()
+        array_begin = Literal("[").suppress()
+        array_end = Literal("]").suppress()
+        tag_begin = Literal("<").suppress()
+        tag_end = Literal(">").suppress()
+        eql = Literal("=").suppress()
         dmark = Literal('$').suppress()
-        end_data=Literal('$end').suppress()
-        prtable = alphanums+r'!$%&*+-./<>?@^_|~'
-        ival=Regex('[-]?\d+')
-        dval=Regex('-?\d+\.\d*([eE]?[+-]?\d+)?')
-        lval=Regex('([Yy]es|[Nn]o|[Tt]rue|[Ff]alse|[Oo]n|[Oo]ff)')
+        end_data = Literal('$end').suppress()
+        prtable = alphanums + r'!$%&*+-./<>?@^_|~'
+        ival = Regex('[-]?\d+')
+        dval = Regex('-?\d+\.\d*([eE]?[+-]?\d+)?')
+        lval = Regex('([Yy]es|[Nn]o|[Tt]rue|[Ff]alse|[Oo]n|[Oo]ff)')
 
         # Helper definitions
 
         kstr= quotedString.setParseAction(removeQuotes) ^ \
                 dval ^ ival ^ lval ^ Word(prtable)
-        name = Word(alphas+"_",alphanums+"_")
+        name = Word(alphas + "_", alphanums + "_")
         vec=array_begin+delimitedList(dval ^ ival ^ lval ^ Word(prtable) ^ \
                 Literal("\n").suppress() ^ \
                 quotedString.setParseAction(removeQuotes))+array_end
-        sect=name+sect_begin
-        tag_sect=name+Group(tag_begin+name+tag_end)+sect_begin
+        sect = name + sect_begin
+        tag_sect = name + Group(tag_begin + name + tag_end) + sect_begin
 
         # Grammar
         keyword = name + eql + kstr
         vector = name + eql + vec
-        data=Combine(dmark+name)+SkipTo(end_data)+end_data
-        section=Forward()
-        sect_def=(sect | tag_sect ) #| vec_sect)
-        input=section | data | vector | keyword
-        section << sect_def+ZeroOrMore(input) + sect_end
+        data = Combine(dmark + name) + SkipTo(end_data) + end_data
+        section = Forward()
+        sect_def = (sect | tag_sect)  #| vec_sect)
+        input = section | data | vector | keyword
+        section << sect_def + ZeroOrMore(input) + sect_end
 
         # Parsing actions
         ival.setParseAction(self.conv_ival)
@@ -772,20 +770,21 @@ line: %d" % ( name, lineno(self.loc,self.strg)))
         tag_sect.setParseAction(self.add_sect)
         sect_end.setParseAction(self.pop_sect)
 
-        bnf=ZeroOrMore(input) + StringEnd().setFailAction(parse_error)
+        bnf = ZeroOrMore(input) + StringEnd().setFailAction(parse_error)
         bnf.ignore(pythonStyleComment)
         return bnf
 
-def parse_error(s,t,d,err):
-    print("Parse error, line %d: %s" %  ( lineno(err.loc,err.pstr),
-            line(err.loc,err.pstr)))
+
+def parse_error(s, t, d, err):
+    print("Parse error, line %d: %s" % (lineno(err.loc, err.pstr), line(err.loc, err.pstr)))
     sys.exit(1)
 
 ######## Convenience routines for callbacks ########
 
-def check_opt(sect,key):
+
+def check_opt(sect, key):
     try:
-        k=sect[key]
+        k = sect[key]
     except:
         print('You have a typo in the code for key', key)
         sys.exit(1)
@@ -794,8 +793,9 @@ def check_opt(sect,key):
             return True
     return False
 
+
 def check_required(list, sect):
-    err="Error: Required option '%s' not set in section '%s%s'!"
+    err = "Error: Required option '%s' not set in section '%s%s'!"
     for i in list:
         if not check_opt(sect, i):
             if sect.name == sect.tag or sect.tag is None:
@@ -804,8 +804,9 @@ def check_required(list, sect):
                 print(err % (i, sect.name, '<' + sect.tag + '>'))
             sys.exit(1)
 
+
 def check_ignored(list, sect):
-    warn="Warning: The '%s' option will be ignored in section '%s%s'."
+    warn = "Warning: The '%s' option will be ignored in section '%s%s'."
     for i in list:
         if check_opt(sect, i):
             if sect.name == sect.tag:
@@ -815,18 +816,20 @@ def check_ignored(list, sect):
 
 ####################################################
 
-def test( strng ):
+
+def test(strng):
     bnf = GetkwParser()
     try:
-        tokens=bnf.parseString(strng)
+        tokens = bnf.parseString(strng)
     except ParseException as err:
         print(err.line)
-        print(" "*(err.column-1) + "^")
+        print(" " * (err.column - 1) + "^")
         print(err)
     return tokens
 
+
 if __name__ == '__main__':
-    teststr="""
+    teststr = """
 title = foo
 string="fooo bar"
 
@@ -879,4 +882,3 @@ raboof {
     print(ini.top)
 #    foo=ini.get_keyword('raboof.foo')
 #    print dir(foo)
-

--- a/tools/pyparsing.py
+++ b/tools/pyparsing.py
@@ -73,23 +73,109 @@ import pprint
 #~ sys.stderr.write( "testing pyparsing module, version %s, %s\n" % (__version__,__versionTime__ ) )
 
 __all__ = [
-'And', 'CaselessKeyword', 'CaselessLiteral', 'CharsNotIn', 'Combine', 'Dict', 'Each', 'Empty',
-'FollowedBy', 'Forward', 'GoToColumn', 'Group', 'Keyword', 'LineEnd', 'LineStart', 'Literal',
-'MatchFirst', 'NoMatch', 'NotAny', 'OneOrMore', 'OnlyOnce', 'Optional', 'Or',
-'ParseBaseException', 'ParseElementEnhance', 'ParseException', 'ParseExpression', 'ParseFatalException',
-'ParseResults', 'ParseSyntaxException', 'ParserElement', 'QuotedString', 'RecursiveGrammarException',
-'Regex', 'SkipTo', 'StringEnd', 'StringStart', 'Suppress', 'Token', 'TokenConverter', 'Upcase',
-'White', 'Word', 'WordEnd', 'WordStart', 'ZeroOrMore',
-'alphanums', 'alphas', 'alphas8bit', 'anyCloseTag', 'anyOpenTag', 'cStyleComment', 'col',
-'commaSeparatedList', 'commonHTMLEntity', 'countedArray', 'cppStyleComment', 'dblQuotedString',
-'dblSlashComment', 'delimitedList', 'dictOf', 'downcaseTokens', 'empty', 'hexnums',
-'htmlComment', 'javaStyleComment', 'keepOriginalText', 'line', 'lineEnd', 'lineStart', 'lineno',
-'makeHTMLTags', 'makeXMLTags', 'matchOnlyAtCol', 'matchPreviousExpr', 'matchPreviousLiteral',
-'nestedExpr', 'nullDebugAction', 'nums', 'oneOf', 'opAssoc', 'operatorPrecedence', 'printables',
-'punc8bit', 'pythonStyleComment', 'quotedString', 'removeQuotes', 'replaceHTMLEntity', 
-'replaceWith', 'restOfLine', 'sglQuotedString', 'srange', 'stringEnd',
-'stringStart', 'traceParseAction', 'unicodeString', 'upcaseTokens', 'withAttribute',
-'indentedBlock', 'originalTextFor', 'ungroup', 'infixNotation','locatedExpr',
+    'And',
+    'CaselessKeyword',
+    'CaselessLiteral',
+    'CharsNotIn',
+    'Combine',
+    'Dict',
+    'Each',
+    'Empty',
+    'FollowedBy',
+    'Forward',
+    'GoToColumn',
+    'Group',
+    'Keyword',
+    'LineEnd',
+    'LineStart',
+    'Literal',
+    'MatchFirst',
+    'NoMatch',
+    'NotAny',
+    'OneOrMore',
+    'OnlyOnce',
+    'Optional',
+    'Or',
+    'ParseBaseException',
+    'ParseElementEnhance',
+    'ParseException',
+    'ParseExpression',
+    'ParseFatalException',
+    'ParseResults',
+    'ParseSyntaxException',
+    'ParserElement',
+    'QuotedString',
+    'RecursiveGrammarException',
+    'Regex',
+    'SkipTo',
+    'StringEnd',
+    'StringStart',
+    'Suppress',
+    'Token',
+    'TokenConverter',
+    'Upcase',
+    'White',
+    'Word',
+    'WordEnd',
+    'WordStart',
+    'ZeroOrMore',
+    'alphanums',
+    'alphas',
+    'alphas8bit',
+    'anyCloseTag',
+    'anyOpenTag',
+    'cStyleComment',
+    'col',
+    'commaSeparatedList',
+    'commonHTMLEntity',
+    'countedArray',
+    'cppStyleComment',
+    'dblQuotedString',
+    'dblSlashComment',
+    'delimitedList',
+    'dictOf',
+    'downcaseTokens',
+    'empty',
+    'hexnums',
+    'htmlComment',
+    'javaStyleComment',
+    'keepOriginalText',
+    'line',
+    'lineEnd',
+    'lineStart',
+    'lineno',
+    'makeHTMLTags',
+    'makeXMLTags',
+    'matchOnlyAtCol',
+    'matchPreviousExpr',
+    'matchPreviousLiteral',
+    'nestedExpr',
+    'nullDebugAction',
+    'nums',
+    'oneOf',
+    'opAssoc',
+    'operatorPrecedence',
+    'printables',
+    'punc8bit',
+    'pythonStyleComment',
+    'quotedString',
+    'removeQuotes',
+    'replaceHTMLEntity',
+    'replaceWith',
+    'restOfLine',
+    'sglQuotedString',
+    'srange',
+    'stringEnd',
+    'stringStart',
+    'traceParseAction',
+    'unicodeString',
+    'upcaseTokens',
+    'withAttribute',
+    'indentedBlock',
+    'originalTextFor',
+    'ungroup',
+    'infixNotation',
+    'locatedExpr',
 ]
 
 PY_3 = sys.version.startswith('3')
@@ -111,7 +197,7 @@ else:
            str(obj). If that fails with a UnicodeEncodeError, then it tries unicode(obj). It
            then < returns the unicode object | encodes it with the default encoding | ... >.
         """
-        if isinstance(obj,unicode):
+        if isinstance(obj, unicode):
             return obj
 
         try:
@@ -133,42 +219,48 @@ else:
             #return unicode(obj).encode(sys.getdefaultencoding(), 'replace')
             # ...
 
-    # build list of single arg builtins, tolerant of Python version, that can be used as parse actions
+        # build list of single arg builtins, tolerant of Python version, that can be used as parse actions
+
     singleArgBuiltins = []
     import __builtin__
     for fname in "sum len sorted reversed list tuple set any all min max".split():
         try:
-            singleArgBuiltins.append(getattr(__builtin__,fname))
+            singleArgBuiltins.append(getattr(__builtin__, fname))
         except AttributeError:
             continue
-            
+
 _generatorType = type((y for y in range(1)))
- 
+
+
 def _xml_escape(data):
     """Escape &, <, >, ", ', etc. in a string of data."""
 
     # ampersand must be replaced first
     from_symbols = '&><"\''
-    to_symbols = ('&'+s+';' for s in "amp gt lt quot apos".split())
-    for from_,to_ in zip(from_symbols, to_symbols):
+    to_symbols = ('&' + s + ';' for s in "amp gt lt quot apos".split())
+    for from_, to_ in zip(from_symbols, to_symbols):
         data = data.replace(from_, to_)
     return data
+
 
 class _Constants(object):
     pass
 
+
 alphas = string.ascii_lowercase + string.ascii_uppercase
-nums       = "0123456789"
-hexnums    = nums + "ABCDEFabcdef"
-alphanums  = alphas + nums
-_bslash    = chr(92)
+nums = "0123456789"
+hexnums = nums + "ABCDEFabcdef"
+alphanums = alphas + nums
+_bslash = chr(92)
 printables = "".join(c for c in string.printable if c not in string.whitespace)
+
 
 class ParseBaseException(Exception):
     """base exception class for all parsing runtime exceptions"""
+
     # Performance tuning: we construct a *lot* of these, so keep this
     # constructor as small and fast as possible
-    def __init__( self, pstr, loc=0, msg=None, elem=None ):
+    def __init__(self, pstr, loc=0, msg=None, elem=None):
         self.loc = loc
         if msg is None:
             self.msg = pstr
@@ -178,39 +270,42 @@ class ParseBaseException(Exception):
             self.pstr = pstr
         self.parserElement = elem
 
-    def __getattr__( self, aname ):
+    def __getattr__(self, aname):
         """supported attributes by name are:
             - lineno - returns the line number of the exception text
             - col - returns the column number of the exception text
             - line - returns the line containing the exception text
         """
-        if( aname == "lineno" ):
-            return lineno( self.loc, self.pstr )
-        elif( aname in ("col", "column") ):
-            return col( self.loc, self.pstr )
-        elif( aname == "line" ):
-            return line( self.loc, self.pstr )
+        if (aname == "lineno"):
+            return lineno(self.loc, self.pstr)
+        elif (aname in ("col", "column")):
+            return col(self.loc, self.pstr)
+        elif (aname == "line"):
+            return line(self.loc, self.pstr)
         else:
             raise AttributeError(aname)
 
-    def __str__( self ):
+    def __str__(self):
         return "%s (at char %d), (line:%d, col:%d)" % \
                 ( self.msg, self.loc, self.lineno, self.column )
-    def __repr__( self ):
+
+    def __repr__(self):
         return _ustr(self)
-    def markInputline( self, markerString = ">!<" ):
+
+    def markInputline(self, markerString=">!<"):
         """Extracts the exception line from the input string, and marks
            the location of the exception with a special symbol.
         """
         line_str = self.line
         line_column = self.column - 1
         if markerString:
-            line_str = "".join((line_str[:line_column],
-                                markerString, line_str[line_column:]))
+            line_str = "".join((line_str[:line_column], markerString, line_str[line_column:]))
         return line_str.strip()
+
     def __dir__(self):
         return "loc msg pstr parserElement lineno col line " \
                "markInputline __str__ __repr__".split()
+
 
 class ParseException(ParseBaseException):
     """exception thrown when parse expressions don't match class;
@@ -221,49 +316,58 @@ class ParseException(ParseBaseException):
     """
     pass
 
+
 class ParseFatalException(ParseBaseException):
     """user-throwable exception thrown when inconsistent parse content
        is found; stops all parsing immediately"""
     pass
 
+
 class ParseSyntaxException(ParseFatalException):
     """just like C{L{ParseFatalException}}, but thrown internally when an
        C{L{ErrorStop<And._ErrorStop>}} ('-' operator) indicates that parsing is to stop immediately because
        an unbacktrackable syntax error has been found"""
+
     def __init__(self, pe):
-        super(ParseSyntaxException, self).__init__(
-                                    pe.pstr, pe.loc, pe.msg, pe.parserElement)
+        super(ParseSyntaxException, self).__init__(pe.pstr, pe.loc, pe.msg, pe.parserElement)
 
 #~ class ReparseException(ParseBaseException):
-    #~ """Experimental class - parse actions can raise this exception to cause
-       #~ pyparsing to reparse the input string:
-        #~ - with a modified input string, and/or
-        #~ - with a modified start location
-       #~ Set the values of the ReparseException in the constructor, and raise the
-       #~ exception in a parse action to cause pyparsing to use the new string/location.
-       #~ Setting the values as None causes no change to be made.
-       #~ """
-    #~ def __init_( self, newstring, restartLoc ):
-        #~ self.newParseText = newstring
-        #~ self.reparseLoc = restartLoc
+#~ """Experimental class - parse actions can raise this exception to cause
+#~ pyparsing to reparse the input string:
+#~ - with a modified input string, and/or
+#~ - with a modified start location
+#~ Set the values of the ReparseException in the constructor, and raise the
+#~ exception in a parse action to cause pyparsing to use the new string/location.
+#~ Setting the values as None causes no change to be made.
+#~ """
+#~ def __init_( self, newstring, restartLoc ):
+#~ self.newParseText = newstring
+#~ self.reparseLoc = restartLoc
+
 
 class RecursiveGrammarException(Exception):
     """exception thrown by C{validate()} if the grammar could be improperly recursive"""
-    def __init__( self, parseElementList ):
+
+    def __init__(self, parseElementList):
         self.parseElementTrace = parseElementList
 
-    def __str__( self ):
+    def __str__(self):
         return "RecursiveGrammarException: %s" % self.parseElementTrace
 
+
 class _ParseResultsWithOffset(object):
-    def __init__(self,p1,p2):
-        self.tup = (p1,p2)
-    def __getitem__(self,i):
+    def __init__(self, p1, p2):
+        self.tup = (p1, p2)
+
+    def __getitem__(self, i):
         return self.tup[i]
+
     def __repr__(self):
         return repr(self.tup)
-    def setOffset(self,i):
-        self.tup = (self.tup[0],i)
+
+    def setOffset(self, i):
+        self.tup = (self.tup[0], i)
+
 
 class ParseResults(object):
     """Structured parse results, to provide multiple means of access to the parsed data:
@@ -271,7 +375,8 @@ class ParseResults(object):
        - by list index (C{results[0], results[1]}, etc.)
        - by attribute (C{results.<resultsName>})
        """
-    def __new__(cls, toklist, name=None, asList=True, modal=True ):
+
+    def __new__(cls, toklist, name=None, asList=True, modal=True):
         if isinstance(toklist, cls):
             return toklist
         retobj = object.__new__(cls)
@@ -280,7 +385,7 @@ class ParseResults(object):
 
     # Performance tuning: we construct a *lot* of these, so keep this
     # constructor as small and fast as possible
-    def __init__( self, toklist, name=None, asList=True, modal=True, isinstance=isinstance ):
+    def __init__(self, toklist, name=None, asList=True, modal=True, isinstance=isinstance):
         if self.__doinit:
             self.__doinit = False
             self.__name = None
@@ -297,56 +402,56 @@ class ParseResults(object):
         if name is not None and name:
             if not modal:
                 self.__accumNames[name] = 0
-            if isinstance(name,int):
-                name = _ustr(name) # will always return a str, but use _ustr for consistency
+            if isinstance(name, int):
+                name = _ustr(name)  # will always return a str, but use _ustr for consistency
             self.__name = name
-            if not (isinstance(toklist, (type(None), basestring, list)) and toklist in (None,'',[])):
-                if isinstance(toklist,basestring):
-                    toklist = [ toklist ]
+            if not (isinstance(toklist, (type(None), basestring, list)) and toklist in (None, '', [])):
+                if isinstance(toklist, basestring):
+                    toklist = [toklist]
                 if asList:
-                    if isinstance(toklist,ParseResults):
-                        self[name] = _ParseResultsWithOffset(toklist.copy(),0)
+                    if isinstance(toklist, ParseResults):
+                        self[name] = _ParseResultsWithOffset(toklist.copy(), 0)
                     else:
-                        self[name] = _ParseResultsWithOffset(ParseResults(toklist[0]),0)
+                        self[name] = _ParseResultsWithOffset(ParseResults(toklist[0]), 0)
                     self[name].__name = name
                 else:
                     try:
                         self[name] = toklist[0]
-                    except (KeyError,TypeError,IndexError):
+                    except (KeyError, TypeError, IndexError):
                         self[name] = toklist
 
-    def __getitem__( self, i ):
-        if isinstance( i, (int,slice) ):
+    def __getitem__(self, i):
+        if isinstance(i, (int, slice)):
             return self.__toklist[i]
         else:
             if i not in self.__accumNames:
                 return self.__tokdict[i][-1][0]
             else:
-                return ParseResults([ v[0] for v in self.__tokdict[i] ])
+                return ParseResults([v[0] for v in self.__tokdict[i]])
 
-    def __setitem__( self, k, v, isinstance=isinstance ):
-        if isinstance(v,_ParseResultsWithOffset):
-            self.__tokdict[k] = self.__tokdict.get(k,list()) + [v]
+    def __setitem__(self, k, v, isinstance=isinstance):
+        if isinstance(v, _ParseResultsWithOffset):
+            self.__tokdict[k] = self.__tokdict.get(k, list()) + [v]
             sub = v[0]
-        elif isinstance(k,int):
+        elif isinstance(k, int):
             self.__toklist[k] = v
             sub = v
         else:
-            self.__tokdict[k] = self.__tokdict.get(k,list()) + [_ParseResultsWithOffset(v,0)]
+            self.__tokdict[k] = self.__tokdict.get(k, list()) + [_ParseResultsWithOffset(v, 0)]
             sub = v
-        if isinstance(sub,ParseResults):
+        if isinstance(sub, ParseResults):
             sub.__parent = wkref(self)
 
-    def __delitem__( self, i ):
-        if isinstance(i,(int,slice)):
-            mylen = len( self.__toklist )
+    def __delitem__(self, i):
+        if isinstance(i, (int, slice)):
+            mylen = len(self.__toklist)
             del self.__toklist[i]
 
             # convert int to slice
             if isinstance(i, int):
                 if i < 0:
                     i += mylen
-                i = slice(i, i+1)
+                i = slice(i, i + 1)
             # get removed indices
             removed = list(range(*i.indices(mylen)))
             removed.reverse()
@@ -359,26 +464,35 @@ class ParseResults(object):
         else:
             del self.__tokdict[i]
 
-    def __contains__( self, k ):
+    def __contains__(self, k):
         return k in self.__tokdict
 
-    def __len__( self ): return len( self.__toklist )
-    def __bool__(self): return len( self.__toklist ) > 0
+    def __len__(self):
+        return len(self.__toklist)
+
+    def __bool__(self):
+        return len(self.__toklist) > 0
+
     __nonzero__ = __bool__
-    def __iter__( self ): return iter( self.__toklist )
-    def __reversed__( self ): return iter( self.__toklist[::-1] )
-    def iterkeys( self ):
+
+    def __iter__(self):
+        return iter(self.__toklist)
+
+    def __reversed__(self):
+        return iter(self.__toklist[::-1])
+
+    def iterkeys(self):
         """Returns all named result keys."""
         if hasattr(self.__tokdict, "iterkeys"):
             return self.__tokdict.iterkeys()
         else:
             return iter(self.__tokdict)
 
-    def itervalues( self ):
+    def itervalues(self):
         """Returns all named result values."""
         return (self[k] for k in self.iterkeys())
-            
-    def iteritems( self ):
+
+    def iteritems(self):
         return ((k, self[k]) for k in self.iterkeys())
 
     if PY_3:
@@ -386,24 +500,25 @@ class ParseResults(object):
         values = itervalues
         items = iteritems
     else:
-        def keys( self ):
+
+        def keys(self):
             """Returns all named result keys."""
             return list(self.iterkeys())
 
-        def values( self ):
+        def values(self):
             """Returns all named result values."""
             return list(self.itervalues())
-                
-        def items( self ):
+
+        def items(self):
             """Returns all named result keys and values as a list of tuples."""
             return list(self.iteritems())
 
-    def haskeys( self ):
+    def haskeys(self):
         """Since keys() returns an iterator, this method is helpful in bypassing
            code that looks for the existence of any defined results names."""
         return bool(self.__tokdict)
-        
-    def pop( self, *args, **kwargs):
+
+    def pop(self, *args, **kwargs):
         """Removes and returns item at specified index (default=last).
            Supports both list and dict semantics for pop(). If passed no
            argument or an integer argument, it will use list semantics
@@ -414,14 +529,12 @@ class ParseResults(object):
            supported, just as in dict.pop()."""
         if not args:
             args = [-1]
-        for k,v in kwargs.items():
+        for k, v in kwargs.items():
             if k == 'default':
                 args = (args[0], v)
             else:
                 raise TypeError("pop() got an unexpected keyword argument '%s'" % k)
-        if (isinstance(args[0], int) or 
-                        len(args) == 1 or 
-                        args[0] in self):
+        if (isinstance(args[0], int) or len(args) == 1 or args[0] in self):
             index = args[0]
             ret = self[index]
             del self[index]
@@ -439,7 +552,7 @@ class ParseResults(object):
         else:
             return defaultValue
 
-    def insert( self, index, insStr ):
+    def insert(self, index, insStr):
         """Inserts new element at location index in the list of parsed tokens."""
         self.__toklist.insert(index, insStr)
         # fixup indices in token dictionary
@@ -448,65 +561,65 @@ class ParseResults(object):
             for k, (value, position) in enumerate(occurrences):
                 occurrences[k] = _ParseResultsWithOffset(value, position + (position > index))
 
-    def append( self, item ):
+    def append(self, item):
         """Add single element to end of ParseResults list of elements."""
         self.__toklist.append(item)
 
-    def extend( self, itemseq ):
+    def extend(self, itemseq):
         """Add sequence of elements to end of ParseResults list of elements."""
         if isinstance(itemseq, ParseResults):
             self += itemseq
         else:
             self.__toklist.extend(itemseq)
 
-    def clear( self ):
+    def clear(self):
         """Clear all elements and results names."""
         del self.__toklist[:]
         self.__tokdict.clear()
 
-    def __getattr__( self, name ):
+    def __getattr__(self, name):
         try:
             return self[name]
         except KeyError:
             return ""
-            
+
         if name in self.__tokdict:
             if name not in self.__accumNames:
                 return self.__tokdict[name][-1][0]
             else:
-                return ParseResults([ v[0] for v in self.__tokdict[name] ])
+                return ParseResults([v[0] for v in self.__tokdict[name]])
         else:
             return ""
 
-    def __add__( self, other ):
+    def __add__(self, other):
         ret = self.copy()
         ret += other
         return ret
 
-    def __iadd__( self, other ):
+    def __iadd__(self, other):
         if other.__tokdict:
             offset = len(self.__toklist)
-            addoffset = ( lambda a: (a<0 and offset) or (a+offset) )
+            addoffset = (lambda a: (a < 0 and offset) or (a + offset))
             otheritems = other.__tokdict.items()
-            otherdictitems = [(k, _ParseResultsWithOffset(v[0],addoffset(v[1])) )
-                                for (k,vlist) in otheritems for v in vlist]
-            for k,v in otherdictitems:
+            otherdictitems = [(k, _ParseResultsWithOffset(v[0], addoffset(v[1])))
+                              for (k, vlist) in otheritems for v in vlist]
+            for k, v in otherdictitems:
                 self[k] = v
-                if isinstance(v[0],ParseResults):
+                if isinstance(v[0], ParseResults):
                     v[0].__parent = wkref(self)
-            
+
         self.__toklist += other.__toklist
-        self.__accumNames.update( other.__accumNames )
+        self.__accumNames.update(other.__accumNames)
         return self
 
     def __radd__(self, other):
-        if isinstance(other,int) and other == 0:
+        if isinstance(other, int) and other == 0:
             return self.copy()
-        
-    def __repr__( self ):
-        return "(%s, %s)" % ( repr( self.__toklist ), repr( self.__tokdict ) )
 
-    def __str__( self ):
+    def __repr__(self):
+        return "(%s, %s)" % (repr(self.__toklist), repr(self.__tokdict))
+
+    def __str__(self):
         out = []
         for i in self.__toklist:
             if isinstance(i, ParseResults):
@@ -515,49 +628,48 @@ class ParseResults(object):
                 out.append(repr(i))
         return '[' + ', '.join(out) + ']'
 
-    def _asStringList( self, sep='' ):
+    def _asStringList(self, sep=''):
         out = []
         for item in self.__toklist:
             if out and sep:
                 out.append(sep)
-            if isinstance( item, ParseResults ):
+            if isinstance(item, ParseResults):
                 out += item._asStringList()
             else:
-                out.append( _ustr(item) )
+                out.append(_ustr(item))
         return out
 
-    def asList( self ):
+    def asList(self):
         """Returns the parse results as a nested list of matching tokens, all converted to strings."""
         out = []
         for res in self.__toklist:
-            if isinstance(res,ParseResults):
-                out.append( res.asList() )
+            if isinstance(res, ParseResults):
+                out.append(res.asList())
             else:
-                out.append( res )
+                out.append(res)
         return out
 
-    def asDict( self ):
+    def asDict(self):
         """Returns the named parse results as dictionary."""
         if PY_3:
-            return dict( self.items() )
+            return dict(self.items())
         else:
-            return dict( self.iteritems() )
+            return dict(self.iteritems())
 
-    def copy( self ):
+    def copy(self):
         """Returns a new copy of a C{ParseResults} object."""
-        ret = ParseResults( self.__toklist )
+        ret = ParseResults(self.__toklist)
         ret.__tokdict = self.__tokdict.copy()
         ret.__parent = self.__parent
-        ret.__accumNames.update( self.__accumNames )
+        ret.__accumNames.update(self.__accumNames)
         ret.__name = self.__name
         return ret
 
-    def asXML( self, doctag=None, namedItemsOnly=False, indent="", formatted=True ):
+    def asXML(self, doctag=None, namedItemsOnly=False, indent="", formatted=True):
         """Returns the parse results as XML. Tags are created for tokens and lists that have defined results names."""
         nl = "\n"
         out = []
-        namedItems = dict((v[1],k) for (k,vlist) in self.__tokdict.items()
-                                                            for v in vlist)
+        namedItems = dict((v[1], k) for (k, vlist) in self.__tokdict.items() for v in vlist)
         nextLevelIndent = indent + "  "
 
         # collapse out indents if formatting is not desired
@@ -579,21 +691,15 @@ class ParseResults(object):
             else:
                 selfTag = "ITEM"
 
-        out += [ nl, indent, "<", selfTag, ">" ]
+        out += [nl, indent, "<", selfTag, ">"]
 
         worklist = self.__toklist
-        for i,res in enumerate(worklist):
-            if isinstance(res,ParseResults):
+        for i, res in enumerate(worklist):
+            if isinstance(res, ParseResults):
                 if i in namedItems:
-                    out += [ res.asXML(namedItems[i],
-                                        namedItemsOnly and doctag is None,
-                                        nextLevelIndent,
-                                        formatted)]
+                    out += [res.asXML(namedItems[i], namedItemsOnly and doctag is None, nextLevelIndent, formatted)]
                 else:
-                    out += [ res.asXML(None,
-                                        namedItemsOnly and doctag is None,
-                                        nextLevelIndent,
-                                        formatted)]
+                    out += [res.asXML(None, namedItemsOnly and doctag is None, nextLevelIndent, formatted)]
             else:
                 # individual token, see if there is a name for it
                 resTag = None
@@ -605,16 +711,14 @@ class ParseResults(object):
                     else:
                         resTag = "ITEM"
                 xmlBodyText = _xml_escape(_ustr(res))
-                out += [ nl, nextLevelIndent, "<", resTag, ">",
-                                                xmlBodyText,
-                                                "</", resTag, ">" ]
+                out += [nl, nextLevelIndent, "<", resTag, ">", xmlBodyText, "</", resTag, ">"]
 
-        out += [ nl, indent, "</", selfTag, ">" ]
+        out += [nl, indent, "</", selfTag, ">"]
         return "".join(out)
 
-    def __lookup(self,sub):
-        for k,vlist in self.__tokdict.items():
-            for v,loc in vlist:
+    def __lookup(self, sub):
+        for k, vlist in self.__tokdict.items():
+            for v, loc in vlist:
                 if sub is v:
                     return k
         return None
@@ -629,35 +733,35 @@ class ParseResults(object):
                 return par.__lookup(self)
             else:
                 return None
-        elif (len(self) == 1 and
-               len(self.__tokdict) == 1 and
-               self.__tokdict.values()[0][0][1] in (0,-1)):
+        elif (len(self) == 1 and len(self.__tokdict) == 1 and self.__tokdict.values()[0][0][1] in (0, -1)):
             return self.__tokdict.keys()[0]
         else:
             return None
 
-    def dump(self,indent='',depth=0):
+    def dump(self, indent='', depth=0):
         """Diagnostic method for listing out the contents of a C{ParseResults}.
            Accepts an optional C{indent} argument so that this string can be embedded
            in a nested display of other data."""
         out = []
         NL = '\n'
-        out.append( indent+_ustr(self.asList()) )
+        out.append(indent + _ustr(self.asList()))
         items = sorted(self.items())
-        for k,v in items:
+        for k, v in items:
             if out:
                 out.append(NL)
-            out.append( "%s%s- %s: " % (indent,('  '*depth), k) )
-            if isinstance(v,ParseResults):
+            out.append("%s%s- %s: " % (indent, ('  ' * depth), k))
+            if isinstance(v, ParseResults):
                 if v:
                     if v.haskeys():
-                        out.append( v.dump(indent,depth+1) )
-                    elif any(isinstance(vv,ParseResults) for vv in v):
-                        for i,vv in enumerate(v):
-                            if isinstance(vv,ParseResults):
-                                out.append("\n%s%s[%d]:\n%s%s%s" % (indent,('  '*(depth+1)),i,indent,('  '*(depth+2)),vv.dump(indent,depth+2) ))
+                        out.append(v.dump(indent, depth + 1))
+                    elif any(isinstance(vv, ParseResults) for vv in v):
+                        for i, vv in enumerate(v):
+                            if isinstance(vv, ParseResults):
+                                out.append("\n%s%s[%d]:\n%s%s%s" % (indent, ('  ' * (depth + 1)), i, indent,
+                                                                    ('  ' * (depth + 2)), vv.dump(indent, depth + 2)))
                             else:
-                                out.append("\n%s%s[%d]:\n%s%s%s" % (indent,('  '*(depth+1)),i,indent,('  '*(depth+2)),_ustr(vv)))
+                                out.append("\n%s%s[%d]:\n%s%s%s" % (indent, ('  ' * (depth + 1)), i, indent,
+                                                                    ('  ' * (depth + 2)), _ustr(vv)))
                     else:
                         out.append(_ustr(v))
                 else:
@@ -674,18 +778,12 @@ class ParseResults(object):
 
     # add support for pickle protocol
     def __getstate__(self):
-        return ( self.__toklist,
-                 ( self.__tokdict.copy(),
-                   self.__parent is not None and self.__parent() or None,
-                   self.__accumNames,
-                   self.__name ) )
+        return (self.__toklist, (self.__tokdict.copy(), self.__parent is not None and self.__parent() or None,
+                                 self.__accumNames, self.__name))
 
-    def __setstate__(self,state):
+    def __setstate__(self, state):
         self.__toklist = state[0]
-        (self.__tokdict,
-         par,
-         inAccumNames,
-         self.__name) = state[1]
+        (self.__tokdict, par, inAccumNames, self.__name) = state[1]
         self.__accumNames = {}
         self.__accumNames.update(inAccumNames)
         if par is not None:
@@ -694,11 +792,13 @@ class ParseResults(object):
             self.__parent = None
 
     def __dir__(self):
-        return dir(super(ParseResults,self)) + list(self.keys())
+        return dir(super(ParseResults, self)) + list(self.keys())
+
 
 collections.MutableMapping.register(ParseResults)
 
-def col (loc,strg):
+
+def col(loc, strg):
     """Returns current column within a string, counting newlines as line separators.
    The first column is number 1.
 
@@ -708,9 +808,10 @@ def col (loc,strg):
    consistent view of the parsed string, the parse location, and line and column
    positions within the parsed string.
    """
-    return (loc<len(strg) and strg[loc] == '\n') and 1 or loc - strg.rfind("\n", 0, loc)
+    return (loc < len(strg) and strg[loc] == '\n') and 1 or loc - strg.rfind("\n", 0, loc)
 
-def lineno(loc,strg):
+
+def lineno(loc, strg):
     """Returns current line number within a string, counting newlines as line separators.
    The first line is number 1.
 
@@ -720,26 +821,31 @@ def lineno(loc,strg):
    consistent view of the parsed string, the parse location, and line and column
    positions within the parsed string.
    """
-    return strg.count("\n",0,loc) + 1
+    return strg.count("\n", 0, loc) + 1
 
-def line( loc, strg ):
+
+def line(loc, strg):
     """Returns the line of text containing loc within a string, counting newlines as line separators.
        """
     lastCR = strg.rfind("\n", 0, loc)
     nextCR = strg.find("\n", loc)
     if nextCR >= 0:
-        return strg[lastCR+1:nextCR]
+        return strg[lastCR + 1:nextCR]
     else:
-        return strg[lastCR+1:]
+        return strg[lastCR + 1:]
 
-def _defaultStartDebugAction( instring, loc, expr ):
-    print (("Match " + _ustr(expr) + " at loc " + _ustr(loc) + "(%d,%d)" % ( lineno(loc,instring), col(loc,instring) )))
 
-def _defaultSuccessDebugAction( instring, startloc, endloc, expr, toks ):
-    print ("Matched " + _ustr(expr) + " -> " + str(toks.asList()))
+def _defaultStartDebugAction(instring, loc, expr):
+    print(("Match " + _ustr(expr) + " at loc " + _ustr(loc) + "(%d,%d)" % (lineno(loc, instring), col(loc, instring))))
 
-def _defaultExceptionDebugAction( instring, loc, expr, exc ):
-    print ("Exception raised:" + _ustr(exc))
+
+def _defaultSuccessDebugAction(instring, startloc, endloc, expr, toks):
+    print("Matched " + _ustr(expr) + " -> " + str(toks.asList()))
+
+
+def _defaultExceptionDebugAction(instring, loc, expr, exc):
+    print("Exception raised:" + _ustr(exc))
+
 
 def nullDebugAction(*args):
     """'Do-nothing' debug action, to suppress debugging output during parsing."""
@@ -748,31 +854,34 @@ def nullDebugAction(*args):
 # Only works on Python 3.x - nonlocal is toxic to Python 2 installs
 #~ 'decorator to trim function calls to match the arity of the target'
 #~ def _trim_arity(func, maxargs=3):
-    #~ if func in singleArgBuiltins:
-        #~ return lambda s,l,t: func(t)
-    #~ limit = 0
-    #~ foundArity = False
-    #~ def wrapper(*args):
-        #~ nonlocal limit,foundArity
-        #~ while 1:
-            #~ try:
-                #~ ret = func(*args[limit:])
-                #~ foundArity = True
-                #~ return ret
-            #~ except TypeError:
-                #~ if limit == maxargs or foundArity:
-                    #~ raise
-                #~ limit += 1
-                #~ continue
-    #~ return wrapper
+#~ if func in singleArgBuiltins:
+#~ return lambda s,l,t: func(t)
+#~ limit = 0
+#~ foundArity = False
+#~ def wrapper(*args):
+#~ nonlocal limit,foundArity
+#~ while 1:
+#~ try:
+#~ ret = func(*args[limit:])
+#~ foundArity = True
+#~ return ret
+#~ except TypeError:
+#~ if limit == maxargs or foundArity:
+#~ raise
+#~ limit += 1
+#~ continue
+#~ return wrapper
 
 # this version is Python 2.x-3.x cross-compatible
 'decorator to trim function calls to match the arity of the target'
+
+
 def _trim_arity(func, maxargs=2):
     if func in singleArgBuiltins:
-        return lambda s,l,t: func(t)
+        return lambda s, l, t: func(t)
     limit = [0]
     foundArity = [False]
+
     def wrapper(*args):
         while 1:
             try:
@@ -784,17 +893,20 @@ def _trim_arity(func, maxargs=2):
                     limit[0] += 1
                     continue
                 raise
+
     return wrapper
- 
+
+
 class ParserElement(object):
     """Abstract base level parser element class."""
     DEFAULT_WHITE_CHARS = " \n\t\r"
     verbose_stacktrace = False
 
-    def setDefaultWhitespaceChars( chars ):
+    def setDefaultWhitespaceChars(chars):
         """Overrides the default whitespace chars
         """
         ParserElement.DEFAULT_WHITE_CHARS = chars
+
     setDefaultWhitespaceChars = staticmethod(setDefaultWhitespaceChars)
 
     def inlineLiteralsUsing(cls):
@@ -802,9 +914,10 @@ class ParserElement(object):
         Set class to be used for inclusion of string literals into a parser.
         """
         ParserElement.literalStringClass = cls
+
     inlineLiteralsUsing = staticmethod(inlineLiteralsUsing)
 
-    def __init__( self, savelist=False ):
+    def __init__(self, savelist=False):
         self.parseAction = list()
         self.failAction = None
         #~ self.name = "<unknown>"  # don't define self.name, let subclasses try/except upcall
@@ -814,38 +927,38 @@ class ParserElement(object):
         self.skipWhitespace = True
         self.whiteChars = ParserElement.DEFAULT_WHITE_CHARS
         self.copyDefaultWhiteChars = True
-        self.mayReturnEmpty = False # used when checking for left-recursion
+        self.mayReturnEmpty = False  # used when checking for left-recursion
         self.keepTabs = False
         self.ignoreExprs = list()
         self.debug = False
         self.streamlined = False
-        self.mayIndexError = True # used to optimize exception handling for subclasses that don't advance parse index
+        self.mayIndexError = True  # used to optimize exception handling for subclasses that don't advance parse index
         self.errmsg = ""
-        self.modalResults = True # used to mark results names as modal (report only last) or cumulative (list all)
-        self.debugActions = ( None, None, None ) #custom debug actions
+        self.modalResults = True  # used to mark results names as modal (report only last) or cumulative (list all)
+        self.debugActions = (None, None, None)  #custom debug actions
         self.re = None
-        self.callPreparse = True # used to avoid redundant calls to preParse
+        self.callPreparse = True  # used to avoid redundant calls to preParse
         self.callDuringTry = False
 
-    def copy( self ):
+    def copy(self):
         """Make a copy of this C{ParserElement}.  Useful for defining different parse actions
            for the same parsing pattern, using copies of the original parse element."""
-        cpy = copy.copy( self )
+        cpy = copy.copy(self)
         cpy.parseAction = self.parseAction[:]
         cpy.ignoreExprs = self.ignoreExprs[:]
         if self.copyDefaultWhiteChars:
             cpy.whiteChars = ParserElement.DEFAULT_WHITE_CHARS
         return cpy
 
-    def setName( self, name ):
+    def setName(self, name):
         """Define name for this expression, for use in debugging."""
         self.name = name
         self.errmsg = "Expected " + self.name
-        if hasattr(self,"exception"):
+        if hasattr(self, "exception"):
             self.exception.msg = self.errmsg
         return self
 
-    def setResultsName( self, name, listAllMatches=False ):
+    def setResultsName(self, name, listAllMatches=False):
         """Define name for referencing matching tokens as a nested attribute
            of the returned parse results.
            NOTE: this returns a *copy* of the original C{ParserElement} object;
@@ -859,30 +972,32 @@ class ParserElement(object):
         newself = self.copy()
         if name.endswith("*"):
             name = name[:-1]
-            listAllMatches=True
+            listAllMatches = True
         newself.resultsName = name
         newself.modalResults = not listAllMatches
         return newself
 
-    def setBreak(self,breakFlag = True):
+    def setBreak(self, breakFlag=True):
         """Method to invoke the Python pdb debugger when this element is
            about to be parsed. Set C{breakFlag} to True to enable, False to
            disable.
         """
         if breakFlag:
             _parseMethod = self._parse
+
             def breaker(instring, loc, doActions=True, callPreParse=True):
                 import pdb
                 pdb.set_trace()
-                return _parseMethod( instring, loc, doActions, callPreParse )
+                return _parseMethod(instring, loc, doActions, callPreParse)
+
             breaker._originalParseMethod = _parseMethod
             self._parse = breaker
         else:
-            if hasattr(self._parse,"_originalParseMethod"):
+            if hasattr(self._parse, "_originalParseMethod"):
                 self._parse = self._parse._originalParseMethod
         return self
 
-    def setParseAction( self, *fns, **kwargs ):
+    def setParseAction(self, *fns, **kwargs):
         """Define action to perform when successfully matching parse element definition.
            Parse action fn is a callable method with 0-3 arguments, called as C{fn(s,loc,toks)},
            C{fn(loc,toks)}, C{fn(toks)}, or just C{fn()}, where:
@@ -903,13 +1018,13 @@ class ParserElement(object):
         self.callDuringTry = ("callDuringTry" in kwargs and kwargs["callDuringTry"])
         return self
 
-    def addParseAction( self, *fns, **kwargs ):
+    def addParseAction(self, *fns, **kwargs):
         """Add parse action to expression's list of parse actions. See L{I{setParseAction}<setParseAction>}."""
         self.parseAction += list(map(_trim_arity, list(fns)))
         self.callDuringTry = self.callDuringTry or ("callDuringTry" in kwargs and kwargs["callDuringTry"])
         return self
 
-    def setFailAction( self, fn ):
+    def setFailAction(self, fn):
         """Define action to perform if parsing fails at this expression.
            Fail acton fn is a callable function that takes the arguments
            C{fn(s,loc,expr,err)} where:
@@ -922,22 +1037,22 @@ class ParserElement(object):
         self.failAction = fn
         return self
 
-    def _skipIgnorables( self, instring, loc ):
+    def _skipIgnorables(self, instring, loc):
         exprsFound = True
         while exprsFound:
             exprsFound = False
             for e in self.ignoreExprs:
                 try:
                     while 1:
-                        loc,dummy = e._parse( instring, loc )
+                        loc, dummy = e._parse(instring, loc)
                         exprsFound = True
                 except ParseException:
                     pass
         return loc
 
-    def preParse( self, instring, loc ):
+    def preParse(self, instring, loc):
         if self.ignoreExprs:
-            loc = self._skipIgnorables( instring, loc )
+            loc = self._skipIgnorables(instring, loc)
 
         if self.skipWhitespace:
             wt = self.whiteChars
@@ -947,119 +1062,124 @@ class ParserElement(object):
 
         return loc
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         return loc, []
 
-    def postParse( self, instring, loc, tokenlist ):
+    def postParse(self, instring, loc, tokenlist):
         return tokenlist
 
     #~ @profile
-    def _parseNoCache( self, instring, loc, doActions=True, callPreParse=True ):
-        debugging = ( self.debug ) #and doActions )
+    def _parseNoCache(self, instring, loc, doActions=True, callPreParse=True):
+        debugging = (self.debug)  #and doActions )
 
         if debugging or self.failAction:
             #~ print ("Match",self,"at loc",loc,"(%d,%d)" % ( lineno(loc,instring), col(loc,instring) ))
-            if (self.debugActions[0] ):
-                self.debugActions[0]( instring, loc, self )
+            if (self.debugActions[0]):
+                self.debugActions[0](instring, loc, self)
             if callPreParse and self.callPreparse:
-                preloc = self.preParse( instring, loc )
+                preloc = self.preParse(instring, loc)
             else:
                 preloc = loc
             tokensStart = preloc
             try:
                 try:
-                    loc,tokens = self.parseImpl( instring, preloc, doActions )
+                    loc, tokens = self.parseImpl(instring, preloc, doActions)
                 except IndexError:
-                    raise ParseException( instring, len(instring), self.errmsg, self )
+                    raise ParseException(instring, len(instring), self.errmsg, self)
             except ParseBaseException as err:
                 #~ print ("Exception raised:", err)
                 if self.debugActions[2]:
-                    self.debugActions[2]( instring, tokensStart, self, err )
+                    self.debugActions[2](instring, tokensStart, self, err)
                 if self.failAction:
-                    self.failAction( instring, tokensStart, self, err )
+                    self.failAction(instring, tokensStart, self, err)
                 raise
         else:
             if callPreParse and self.callPreparse:
-                preloc = self.preParse( instring, loc )
+                preloc = self.preParse(instring, loc)
             else:
                 preloc = loc
             tokensStart = preloc
             if self.mayIndexError or loc >= len(instring):
                 try:
-                    loc,tokens = self.parseImpl( instring, preloc, doActions )
+                    loc, tokens = self.parseImpl(instring, preloc, doActions)
                 except IndexError:
-                    raise ParseException( instring, len(instring), self.errmsg, self )
+                    raise ParseException(instring, len(instring), self.errmsg, self)
             else:
-                loc,tokens = self.parseImpl( instring, preloc, doActions )
+                loc, tokens = self.parseImpl(instring, preloc, doActions)
 
-        tokens = self.postParse( instring, loc, tokens )
+        tokens = self.postParse(instring, loc, tokens)
 
-        retTokens = ParseResults( tokens, self.resultsName, asList=self.saveAsList, modal=self.modalResults )
+        retTokens = ParseResults(tokens, self.resultsName, asList=self.saveAsList, modal=self.modalResults)
         if self.parseAction and (doActions or self.callDuringTry):
             if debugging:
                 try:
                     for fn in self.parseAction:
-                        tokens = fn( instring, tokensStart, retTokens )
+                        tokens = fn(instring, tokensStart, retTokens)
                         if tokens is not None:
-                            retTokens = ParseResults( tokens,
-                                                      self.resultsName,
-                                                      asList=self.saveAsList and isinstance(tokens,(ParseResults,list)),
-                                                      modal=self.modalResults )
+                            retTokens = ParseResults(
+                                tokens,
+                                self.resultsName,
+                                asList=self.saveAsList and isinstance(tokens, (ParseResults, list)),
+                                modal=self.modalResults)
                 except ParseBaseException as err:
                     #~ print "Exception raised in user parse action:", err
-                    if (self.debugActions[2] ):
-                        self.debugActions[2]( instring, tokensStart, self, err )
+                    if (self.debugActions[2]):
+                        self.debugActions[2](instring, tokensStart, self, err)
                     raise
             else:
                 for fn in self.parseAction:
-                    tokens = fn( instring, tokensStart, retTokens )
+                    tokens = fn(instring, tokensStart, retTokens)
                     if tokens is not None:
-                        retTokens = ParseResults( tokens,
-                                                  self.resultsName,
-                                                  asList=self.saveAsList and isinstance(tokens,(ParseResults,list)),
-                                                  modal=self.modalResults )
+                        retTokens = ParseResults(
+                            tokens,
+                            self.resultsName,
+                            asList=self.saveAsList and isinstance(tokens, (ParseResults, list)),
+                            modal=self.modalResults)
 
         if debugging:
             #~ print ("Matched",self,"->",retTokens.asList())
-            if (self.debugActions[1] ):
-                self.debugActions[1]( instring, tokensStart, loc, self, retTokens )
+            if (self.debugActions[1]):
+                self.debugActions[1](instring, tokensStart, loc, self, retTokens)
 
         return loc, retTokens
 
-    def tryParse( self, instring, loc ):
+    def tryParse(self, instring, loc):
         try:
-            return self._parse( instring, loc, doActions=False )[0]
+            return self._parse(instring, loc, doActions=False)[0]
         except ParseFatalException:
-            raise ParseException( instring, loc, self.errmsg, self)
+            raise ParseException(instring, loc, self.errmsg, self)
 
     # this method gets repeatedly called during backtracking with the same arguments -
     # we can cache these arguments and save ourselves the trouble of re-parsing the contained expression
-    def _parseCache( self, instring, loc, doActions=True, callPreParse=True ):
-        lookup = (self,instring,loc,callPreParse,doActions)
+    def _parseCache(self, instring, loc, doActions=True, callPreParse=True):
+        lookup = (self, instring, loc, callPreParse, doActions)
         if lookup in ParserElement._exprArgCache:
-            value = ParserElement._exprArgCache[ lookup ]
+            value = ParserElement._exprArgCache[lookup]
             if isinstance(value, Exception):
                 raise value
-            return (value[0],value[1].copy())
+            return (value[0], value[1].copy())
         else:
             try:
-                value = self._parseNoCache( instring, loc, doActions, callPreParse )
-                ParserElement._exprArgCache[ lookup ] = (value[0],value[1].copy())
+                value = self._parseNoCache(instring, loc, doActions, callPreParse)
+                ParserElement._exprArgCache[lookup] = (value[0], value[1].copy())
                 return value
             except ParseBaseException as pe:
                 pe.__traceback__ = None
-                ParserElement._exprArgCache[ lookup ] = pe
+                ParserElement._exprArgCache[lookup] = pe
                 raise
 
     _parse = _parseNoCache
 
     # argument cache for optimizing repeated calls when backtracking through recursive expressions
     _exprArgCache = {}
+
     def resetCache():
         ParserElement._exprArgCache.clear()
+
     resetCache = staticmethod(resetCache)
 
     _packratEnabled = False
+
     def enablePackrat():
         """Enables "packrat" parsing, which adds memoizing to the parsing logic.
            Repeated parse attempts at the same string location (which happens
@@ -1079,9 +1199,10 @@ class ParserElement(object):
         if not ParserElement._packratEnabled:
             ParserElement._packratEnabled = True
             ParserElement._parse = ParserElement._parseCache
+
     enablePackrat = staticmethod(enablePackrat)
 
-    def parseString( self, instring, parseAll=False ):
+    def parseString(self, instring, parseAll=False):
         """Execute the parse expression with the given string.
            This is the main interface to the client code, once the complete
            expression has been built.
@@ -1112,11 +1233,11 @@ class ParserElement(object):
         if not self.keepTabs:
             instring = instring.expandtabs()
         try:
-            loc, tokens = self._parse( instring, 0 )
+            loc, tokens = self._parse(instring, 0)
             if parseAll:
-                loc = self.preParse( instring, loc )
+                loc = self.preParse(instring, loc)
                 se = Empty() + StringEnd()
-                se._parse( instring, loc )
+                se._parse(instring, loc)
         except ParseBaseException as exc:
             if ParserElement.verbose_stacktrace:
                 raise
@@ -1126,7 +1247,7 @@ class ParserElement(object):
         else:
             return tokens
 
-    def scanString( self, instring, maxMatches=_MAX_INT, overlap=False ):
+    def scanString(self, instring, maxMatches=_MAX_INT, overlap=False):
         """Scan the input string for expression matches.  Each match will return the
            matching tokens, start location, and end location.  May be called with optional
            C{maxMatches} argument, to clip scanning after 'n' matches are found.  If
@@ -1151,16 +1272,16 @@ class ParserElement(object):
         try:
             while loc <= instrlen and matches < maxMatches:
                 try:
-                    preloc = preparseFn( instring, loc )
-                    nextLoc,tokens = parseFn( instring, preloc, callPreParse=False )
+                    preloc = preparseFn(instring, loc)
+                    nextLoc, tokens = parseFn(instring, preloc, callPreParse=False)
                 except ParseException:
-                    loc = preloc+1
+                    loc = preloc + 1
                 else:
                     if nextLoc > loc:
                         matches += 1
                         yield tokens, preloc, nextLoc
                         if overlap:
-                            nextloc = preparseFn( instring, loc )
+                            nextloc = preparseFn(instring, loc)
                             if nextloc > loc:
                                 loc = nextLoc
                             else:
@@ -1168,7 +1289,7 @@ class ParserElement(object):
                         else:
                             loc = nextLoc
                     else:
-                        loc = preloc+1
+                        loc = preloc + 1
         except ParseBaseException as exc:
             if ParserElement.verbose_stacktrace:
                 raise
@@ -1176,7 +1297,7 @@ class ParserElement(object):
                 # catch and re-raise exception from here, clears out pyparsing internal stack trace
                 raise exc
 
-    def transformString( self, instring ):
+    def transformString(self, instring):
         """Extension to C{L{scanString}}, to modify matching text with modified tokens that may
            be returned from a parse action.  To use C{transformString}, define a grammar and
            attach a parse action to it that modifies the returned token list.
@@ -1189,19 +1310,19 @@ class ParserElement(object):
         # keep string locs straight between transformString and scanString
         self.keepTabs = True
         try:
-            for t,s,e in self.scanString( instring ):
-                out.append( instring[lastE:s] )
+            for t, s, e in self.scanString(instring):
+                out.append(instring[lastE:s])
                 if t:
-                    if isinstance(t,ParseResults):
+                    if isinstance(t, ParseResults):
                         out += t.asList()
-                    elif isinstance(t,list):
+                    elif isinstance(t, list):
                         out += t
                     else:
                         out.append(t)
                 lastE = e
             out.append(instring[lastE:])
             out = [o for o in out if o]
-            return "".join(map(_ustr,_flatten(out)))
+            return "".join(map(_ustr, _flatten(out)))
         except ParseBaseException as exc:
             if ParserElement.verbose_stacktrace:
                 raise
@@ -1209,13 +1330,13 @@ class ParserElement(object):
                 # catch and re-raise exception from here, clears out pyparsing internal stack trace
                 raise exc
 
-    def searchString( self, instring, maxMatches=_MAX_INT ):
+    def searchString(self, instring, maxMatches=_MAX_INT):
         """Another extension to C{L{scanString}}, simplifying the access to the tokens found
            to match the given parse expression.  May be called with optional
            C{maxMatches} argument, to clip searching after 'n' matches are found.
         """
         try:
-            return ParseResults([ t for t,s,e in self.scanString( instring, maxMatches ) ])
+            return ParseResults([t for t, s, e in self.scanString(instring, maxMatches)])
         except ParseBaseException as exc:
             if ParserElement.verbose_stacktrace:
                 raise
@@ -1223,47 +1344,47 @@ class ParserElement(object):
                 # catch and re-raise exception from here, clears out pyparsing internal stack trace
                 raise exc
 
-    def __add__(self, other ):
+    def __add__(self, other):
         """Implementation of + operator - returns C{L{And}}"""
-        if isinstance( other, basestring ):
-            other = ParserElement.literalStringClass( other )
-        if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
-                    SyntaxWarning, stacklevel=2)
+        if isinstance(other, basestring):
+            other = ParserElement.literalStringClass(other)
+        if not isinstance(other, ParserElement):
+            warnings.warn(
+                "Cannot combine element of type %s with ParserElement" % type(other), SyntaxWarning, stacklevel=2)
             return None
-        return And( [ self, other ] )
+        return And([self, other])
 
-    def __radd__(self, other ):
+    def __radd__(self, other):
         """Implementation of + operator when left operand is not a C{L{ParserElement}}"""
-        if isinstance( other, basestring ):
-            other = ParserElement.literalStringClass( other )
-        if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
-                    SyntaxWarning, stacklevel=2)
+        if isinstance(other, basestring):
+            other = ParserElement.literalStringClass(other)
+        if not isinstance(other, ParserElement):
+            warnings.warn(
+                "Cannot combine element of type %s with ParserElement" % type(other), SyntaxWarning, stacklevel=2)
             return None
         return other + self
 
     def __sub__(self, other):
         """Implementation of - operator, returns C{L{And}} with error stop"""
-        if isinstance( other, basestring ):
-            other = ParserElement.literalStringClass( other )
-        if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
-                    SyntaxWarning, stacklevel=2)
+        if isinstance(other, basestring):
+            other = ParserElement.literalStringClass(other)
+        if not isinstance(other, ParserElement):
+            warnings.warn(
+                "Cannot combine element of type %s with ParserElement" % type(other), SyntaxWarning, stacklevel=2)
             return None
-        return And( [ self, And._ErrorStop(), other ] )
+        return And([self, And._ErrorStop(), other])
 
-    def __rsub__(self, other ):
+    def __rsub__(self, other):
         """Implementation of - operator when left operand is not a C{L{ParserElement}}"""
-        if isinstance( other, basestring ):
-            other = ParserElement.literalStringClass( other )
-        if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
-                    SyntaxWarning, stacklevel=2)
+        if isinstance(other, basestring):
+            other = ParserElement.literalStringClass(other)
+        if not isinstance(other, ParserElement):
+            warnings.warn(
+                "Cannot combine element of type %s with ParserElement" % type(other), SyntaxWarning, stacklevel=2)
             return None
         return other - self
 
-    def __mul__(self,other):
+    def __mul__(self, other):
         """Implementation of * operator, allows use of C{expr * 3} in place of
            C{expr + expr + expr}.  Expressions may also me multiplied by a 2-integer
            tuple, similar to C{{min,max}} multipliers in regular expressions.  Tuples
@@ -1283,24 +1404,25 @@ class ParserElement(object):
            C{expr*(None,n) + ~expr}
 
         """
-        if isinstance(other,int):
-            minElements, optElements = other,0
-        elif isinstance(other,tuple):
+        if isinstance(other, int):
+            minElements, optElements = other, 0
+        elif isinstance(other, tuple):
             other = (other + (None, None))[:2]
             if other[0] is None:
                 other = (0, other[1])
-            if isinstance(other[0],int) and other[1] is None:
+            if isinstance(other[0], int) and other[1] is None:
                 if other[0] == 0:
                     return ZeroOrMore(self)
                 if other[0] == 1:
                     return OneOrMore(self)
                 else:
-                    return self*other[0] + ZeroOrMore(self)
-            elif isinstance(other[0],int) and isinstance(other[1],int):
+                    return self * other[0] + ZeroOrMore(self)
+            elif isinstance(other[0], int) and isinstance(other[1], int):
                 minElements, optElements = other
                 optElements -= minElements
             else:
-                raise TypeError("cannot multiply 'ParserElement' and ('%s','%s') objects", type(other[0]),type(other[1]))
+                raise TypeError("cannot multiply 'ParserElement' and ('%s','%s') objects", type(other[0]),
+                                type(other[1]))
         else:
             raise TypeError("cannot multiply 'ParserElement' and '%s' objects", type(other))
 
@@ -1312,91 +1434,93 @@ class ParserElement(object):
             raise ValueError("cannot multiply ParserElement by 0 or (0,0)")
 
         if (optElements):
+
             def makeOptionalList(n):
-                if n>1:
-                    return Optional(self + makeOptionalList(n-1))
+                if n > 1:
+                    return Optional(self + makeOptionalList(n - 1))
                 else:
                     return Optional(self)
+
             if minElements:
                 if minElements == 1:
                     ret = self + makeOptionalList(optElements)
                 else:
-                    ret = And([self]*minElements) + makeOptionalList(optElements)
+                    ret = And([self] * minElements) + makeOptionalList(optElements)
             else:
                 ret = makeOptionalList(optElements)
         else:
             if minElements == 1:
                 ret = self
             else:
-                ret = And([self]*minElements)
+                ret = And([self] * minElements)
         return ret
 
     def __rmul__(self, other):
         return self.__mul__(other)
 
-    def __or__(self, other ):
+    def __or__(self, other):
         """Implementation of | operator - returns C{L{MatchFirst}}"""
-        if isinstance( other, basestring ):
-            other = ParserElement.literalStringClass( other )
-        if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
-                    SyntaxWarning, stacklevel=2)
+        if isinstance(other, basestring):
+            other = ParserElement.literalStringClass(other)
+        if not isinstance(other, ParserElement):
+            warnings.warn(
+                "Cannot combine element of type %s with ParserElement" % type(other), SyntaxWarning, stacklevel=2)
             return None
-        return MatchFirst( [ self, other ] )
+        return MatchFirst([self, other])
 
-    def __ror__(self, other ):
+    def __ror__(self, other):
         """Implementation of | operator when left operand is not a C{L{ParserElement}}"""
-        if isinstance( other, basestring ):
-            other = ParserElement.literalStringClass( other )
-        if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
-                    SyntaxWarning, stacklevel=2)
+        if isinstance(other, basestring):
+            other = ParserElement.literalStringClass(other)
+        if not isinstance(other, ParserElement):
+            warnings.warn(
+                "Cannot combine element of type %s with ParserElement" % type(other), SyntaxWarning, stacklevel=2)
             return None
         return other | self
 
-    def __xor__(self, other ):
+    def __xor__(self, other):
         """Implementation of ^ operator - returns C{L{Or}}"""
-        if isinstance( other, basestring ):
-            other = ParserElement.literalStringClass( other )
-        if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
-                    SyntaxWarning, stacklevel=2)
+        if isinstance(other, basestring):
+            other = ParserElement.literalStringClass(other)
+        if not isinstance(other, ParserElement):
+            warnings.warn(
+                "Cannot combine element of type %s with ParserElement" % type(other), SyntaxWarning, stacklevel=2)
             return None
-        return Or( [ self, other ] )
+        return Or([self, other])
 
-    def __rxor__(self, other ):
+    def __rxor__(self, other):
         """Implementation of ^ operator when left operand is not a C{L{ParserElement}}"""
-        if isinstance( other, basestring ):
-            other = ParserElement.literalStringClass( other )
-        if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
-                    SyntaxWarning, stacklevel=2)
+        if isinstance(other, basestring):
+            other = ParserElement.literalStringClass(other)
+        if not isinstance(other, ParserElement):
+            warnings.warn(
+                "Cannot combine element of type %s with ParserElement" % type(other), SyntaxWarning, stacklevel=2)
             return None
         return other ^ self
 
-    def __and__(self, other ):
+    def __and__(self, other):
         """Implementation of & operator - returns C{L{Each}}"""
-        if isinstance( other, basestring ):
-            other = ParserElement.literalStringClass( other )
-        if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
-                    SyntaxWarning, stacklevel=2)
+        if isinstance(other, basestring):
+            other = ParserElement.literalStringClass(other)
+        if not isinstance(other, ParserElement):
+            warnings.warn(
+                "Cannot combine element of type %s with ParserElement" % type(other), SyntaxWarning, stacklevel=2)
             return None
-        return Each( [ self, other ] )
+        return Each([self, other])
 
-    def __rand__(self, other ):
+    def __rand__(self, other):
         """Implementation of & operator when left operand is not a C{L{ParserElement}}"""
-        if isinstance( other, basestring ):
-            other = ParserElement.literalStringClass( other )
-        if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
-                    SyntaxWarning, stacklevel=2)
+        if isinstance(other, basestring):
+            other = ParserElement.literalStringClass(other)
+        if not isinstance(other, ParserElement):
+            warnings.warn(
+                "Cannot combine element of type %s with ParserElement" % type(other), SyntaxWarning, stacklevel=2)
             return None
         return other & self
 
-    def __invert__( self ):
+    def __invert__(self):
         """Implementation of ~ operator - returns C{L{NotAny}}"""
-        return NotAny( self )
+        return NotAny(self)
 
     def __call__(self, name=None):
         """Shortcut for C{L{setResultsName}}, with C{listAllMatches=default}::
@@ -1414,13 +1538,13 @@ class ParserElement(object):
         else:
             return self.copy()
 
-    def suppress( self ):
+    def suppress(self):
         """Suppresses the output of this C{ParserElement}; useful to keep punctuation from
            cluttering up returned output.
         """
-        return Suppress( self )
+        return Suppress(self)
 
-    def leaveWhitespace( self ):
+    def leaveWhitespace(self):
         """Disables the skipping of whitespace before matching the characters in the
            C{ParserElement}'s defined pattern.  This is normally only used internally by
            the pyparsing module, but may be needed in some whitespace-sensitive grammars.
@@ -1428,7 +1552,7 @@ class ParserElement(object):
         self.skipWhitespace = False
         return self
 
-    def setWhitespaceChars( self, chars ):
+    def setWhitespaceChars(self, chars):
         """Overrides the default whitespace chars
         """
         self.skipWhitespace = True
@@ -1436,61 +1560,60 @@ class ParserElement(object):
         self.copyDefaultWhiteChars = False
         return self
 
-    def parseWithTabs( self ):
+    def parseWithTabs(self):
         """Overrides default behavior to expand C{<TAB>}s to spaces before parsing the input string.
            Must be called before C{parseString} when the input grammar contains elements that
            match C{<TAB>} characters."""
         self.keepTabs = True
         return self
 
-    def ignore( self, other ):
+    def ignore(self, other):
         """Define expression to be ignored (e.g., comments) while doing pattern
            matching; may be called repeatedly, to define multiple comment or other
            ignorable patterns.
         """
-        if isinstance( other, Suppress ):
+        if isinstance(other, Suppress):
             if other not in self.ignoreExprs:
-                self.ignoreExprs.append( other.copy() )
+                self.ignoreExprs.append(other.copy())
         else:
-            self.ignoreExprs.append( Suppress( other.copy() ) )
+            self.ignoreExprs.append(Suppress(other.copy()))
         return self
 
-    def setDebugActions( self, startAction, successAction, exceptionAction ):
+    def setDebugActions(self, startAction, successAction, exceptionAction):
         """Enable display of debugging messages while doing pattern matching."""
-        self.debugActions = (startAction or _defaultStartDebugAction,
-                             successAction or _defaultSuccessDebugAction,
+        self.debugActions = (startAction or _defaultStartDebugAction, successAction or _defaultSuccessDebugAction,
                              exceptionAction or _defaultExceptionDebugAction)
         self.debug = True
         return self
 
-    def setDebug( self, flag=True ):
+    def setDebug(self, flag=True):
         """Enable display of debugging messages while doing pattern matching.
            Set C{flag} to True to enable, False to disable."""
         if flag:
-            self.setDebugActions( _defaultStartDebugAction, _defaultSuccessDebugAction, _defaultExceptionDebugAction )
+            self.setDebugActions(_defaultStartDebugAction, _defaultSuccessDebugAction, _defaultExceptionDebugAction)
         else:
             self.debug = False
         return self
 
-    def __str__( self ):
+    def __str__(self):
         return self.name
 
-    def __repr__( self ):
+    def __repr__(self):
         return _ustr(self)
 
-    def streamline( self ):
+    def streamline(self):
         self.streamlined = True
         self.strRepr = None
         return self
 
-    def checkRecursion( self, parseElementList ):
+    def checkRecursion(self, parseElementList):
         pass
 
-    def validate( self, validateTrace=[] ):
+    def validate(self, validateTrace=[]):
         """Check defined expressions for valid structure, check for infinite recursive definitions."""
-        self.checkRecursion( [] )
+        self.checkRecursion([])
 
-    def parseFile( self, file_or_filename, parseAll=False ):
+    def parseFile(self, file_or_filename, parseAll=False):
         """Execute the parse expression on the given file or filename.
            If a filename is specified (instead of a file object),
            the entire file is opened, read, and closed before parsing.
@@ -1510,7 +1633,7 @@ class ParserElement(object):
                 # catch and re-raise exception from here, clears out pyparsing internal stack trace
                 raise exc
 
-    def __eq__(self,other):
+    def __eq__(self, other):
         if isinstance(other, ParserElement):
             return self is other or self.__dict__ == other.__dict__
         elif isinstance(other, basestring):
@@ -1520,36 +1643,38 @@ class ParserElement(object):
             except ParseBaseException:
                 return False
         else:
-            return super(ParserElement,self)==other
+            return super(ParserElement, self) == other
 
-    def __ne__(self,other):
+    def __ne__(self, other):
         return not (self == other)
 
     def __hash__(self):
         return hash(id(self))
 
-    def __req__(self,other):
+    def __req__(self, other):
         return self == other
 
-    def __rne__(self,other):
+    def __rne__(self, other):
         return not (self == other)
 
 
 class Token(ParserElement):
     """Abstract C{ParserElement} subclass, for defining atomic matching patterns."""
-    def __init__( self ):
-        super(Token,self).__init__( savelist=False )
+
+    def __init__(self):
+        super(Token, self).__init__(savelist=False)
 
     def setName(self, name):
-        s = super(Token,self).setName(name)
+        s = super(Token, self).setName(name)
         self.errmsg = "Expected " + self.name
         return s
 
 
 class Empty(Token):
     """An empty token, will always match."""
-    def __init__( self ):
-        super(Empty,self).__init__()
+
+    def __init__(self):
+        super(Empty, self).__init__()
         self.name = "Empty"
         self.mayReturnEmpty = True
         self.mayIndexError = False
@@ -1557,28 +1682,29 @@ class Empty(Token):
 
 class NoMatch(Token):
     """A token that will never match."""
-    def __init__( self ):
-        super(NoMatch,self).__init__()
+
+    def __init__(self):
+        super(NoMatch, self).__init__()
         self.name = "NoMatch"
         self.mayReturnEmpty = True
         self.mayIndexError = False
         self.errmsg = "Unmatchable token"
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         raise ParseException(instring, loc, self.errmsg, self)
 
 
 class Literal(Token):
     """Token to exactly match a specified string."""
-    def __init__( self, matchString ):
-        super(Literal,self).__init__()
+
+    def __init__(self, matchString):
+        super(Literal, self).__init__()
         self.match = matchString
         self.matchLen = len(matchString)
         try:
             self.firstMatchChar = matchString[0]
         except IndexError:
-            warnings.warn("null string passed to Literal; use Empty() instead",
-                            SyntaxWarning, stacklevel=2)
+            warnings.warn("null string passed to Literal; use Empty() instead", SyntaxWarning, stacklevel=2)
             self.__class__ = Empty
         self.name = '"%s"' % _ustr(self.match)
         self.errmsg = "Expected " + self.name
@@ -1589,13 +1715,15 @@ class Literal(Token):
     # if this is a single character match string  and the first character matches,
     # short-circuit as quickly as possible, and avoid calling startswith
     #~ @profile
-    def parseImpl( self, instring, loc, doActions=True ):
-        if (instring[loc] == self.firstMatchChar and
-            (self.matchLen==1 or instring.startswith(self.match,loc)) ):
-            return loc+self.matchLen, self.match
+    def parseImpl(self, instring, loc, doActions=True):
+        if (instring[loc] == self.firstMatchChar and (self.matchLen == 1 or instring.startswith(self.match, loc))):
+            return loc + self.matchLen, self.match
         raise ParseException(instring, loc, self.errmsg, self)
+
+
 _L = Literal
 ParserElement.literalStringClass = Literal
+
 
 class Keyword(Token):
     """Token to exactly match a specified string as a keyword, that is, it must be
@@ -1607,17 +1735,16 @@ class Keyword(Token):
        defaulting to all alphanumerics + "_" and "$"; C{caseless} allows case-insensitive
        matching, default is C{False}.
     """
-    DEFAULT_KEYWORD_CHARS = alphanums+"_$"
+    DEFAULT_KEYWORD_CHARS = alphanums + "_$"
 
-    def __init__( self, matchString, identChars=DEFAULT_KEYWORD_CHARS, caseless=False ):
-        super(Keyword,self).__init__()
+    def __init__(self, matchString, identChars=DEFAULT_KEYWORD_CHARS, caseless=False):
+        super(Keyword, self).__init__()
         self.match = matchString
         self.matchLen = len(matchString)
         try:
             self.firstMatchChar = matchString[0]
         except IndexError:
-            warnings.warn("null string passed to Keyword; use Empty() instead",
-                            SyntaxWarning, stacklevel=2)
+            warnings.warn("null string passed to Keyword; use Empty() instead", SyntaxWarning, stacklevel=2)
         self.name = '"%s"' % self.match
         self.errmsg = "Expected " + self.name
         self.mayReturnEmpty = False
@@ -1628,57 +1755,62 @@ class Keyword(Token):
             identChars = identChars.upper()
         self.identChars = set(identChars)
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         if self.caseless:
-            if ( (instring[ loc:loc+self.matchLen ].upper() == self.caselessmatch) and
-                 (loc >= len(instring)-self.matchLen or instring[loc+self.matchLen].upper() not in self.identChars) and
-                 (loc == 0 or instring[loc-1].upper() not in self.identChars) ):
-                return loc+self.matchLen, self.match
+            if ((instring[loc:loc + self.matchLen].upper() == self.caselessmatch) and
+                (loc >= len(instring) - self.matchLen or instring[loc + self.matchLen].upper() not in self.identChars)
+                    and (loc == 0 or instring[loc - 1].upper() not in self.identChars)):
+                return loc + self.matchLen, self.match
         else:
             if (instring[loc] == self.firstMatchChar and
-                (self.matchLen==1 or instring.startswith(self.match,loc)) and
-                (loc >= len(instring)-self.matchLen or instring[loc+self.matchLen] not in self.identChars) and
-                (loc == 0 or instring[loc-1] not in self.identChars) ):
-                return loc+self.matchLen, self.match
+                (self.matchLen == 1 or instring.startswith(self.match, loc)) and
+                (loc >= len(instring) - self.matchLen or instring[loc + self.matchLen] not in self.identChars) and
+                (loc == 0 or instring[loc - 1] not in self.identChars)):
+                return loc + self.matchLen, self.match
         raise ParseException(instring, loc, self.errmsg, self)
 
     def copy(self):
-        c = super(Keyword,self).copy()
+        c = super(Keyword, self).copy()
         c.identChars = Keyword.DEFAULT_KEYWORD_CHARS
         return c
 
-    def setDefaultKeywordChars( chars ):
+    def setDefaultKeywordChars(chars):
         """Overrides the default Keyword chars
         """
         Keyword.DEFAULT_KEYWORD_CHARS = chars
+
     setDefaultKeywordChars = staticmethod(setDefaultKeywordChars)
+
 
 class CaselessLiteral(Literal):
     """Token to match a specified string, ignoring case of letters.
        Note: the matched results will always be in the case of the given
        match string, NOT the case of the input text.
     """
-    def __init__( self, matchString ):
-        super(CaselessLiteral,self).__init__( matchString.upper() )
+
+    def __init__(self, matchString):
+        super(CaselessLiteral, self).__init__(matchString.upper())
         # Preserve the defining literal.
         self.returnString = matchString
         self.name = "'%s'" % self.returnString
         self.errmsg = "Expected " + self.name
 
-    def parseImpl( self, instring, loc, doActions=True ):
-        if instring[ loc:loc+self.matchLen ].upper() == self.match:
-            return loc+self.matchLen, self.returnString
+    def parseImpl(self, instring, loc, doActions=True):
+        if instring[loc:loc + self.matchLen].upper() == self.match:
+            return loc + self.matchLen, self.returnString
         raise ParseException(instring, loc, self.errmsg, self)
+
 
 class CaselessKeyword(Keyword):
-    def __init__( self, matchString, identChars=Keyword.DEFAULT_KEYWORD_CHARS ):
-        super(CaselessKeyword,self).__init__( matchString, identChars, caseless=True )
+    def __init__(self, matchString, identChars=Keyword.DEFAULT_KEYWORD_CHARS):
+        super(CaselessKeyword, self).__init__(matchString, identChars, caseless=True)
 
-    def parseImpl( self, instring, loc, doActions=True ):
-        if ( (instring[ loc:loc+self.matchLen ].upper() == self.caselessmatch) and
-             (loc >= len(instring)-self.matchLen or instring[loc+self.matchLen].upper() not in self.identChars) ):
-            return loc+self.matchLen, self.match
+    def parseImpl(self, instring, loc, doActions=True):
+        if ((instring[loc:loc + self.matchLen].upper() == self.caselessmatch) and
+            (loc >= len(instring) - self.matchLen or instring[loc + self.matchLen].upper() not in self.identChars)):
+            return loc + self.matchLen, self.match
         raise ParseException(instring, loc, self.errmsg, self)
+
 
 class Word(Token):
     """Token for matching words composed of allowed character sets.
@@ -1692,15 +1824,16 @@ class Word(Token):
        the input C{bodyChars} string; useful to define a word of all printables
        except for one or two characters, for instance.
     """
-    def __init__( self, initChars, bodyChars=None, min=1, max=0, exact=0, asKeyword=False, excludeChars=None ):
-        super(Word,self).__init__()
+
+    def __init__(self, initChars, bodyChars=None, min=1, max=0, exact=0, asKeyword=False, excludeChars=None):
+        super(Word, self).__init__()
         if excludeChars:
             initChars = ''.join(c for c in initChars if c not in excludeChars)
             if bodyChars:
                 bodyChars = ''.join(c for c in bodyChars if c not in excludeChars)
         self.initCharsOrig = initChars
         self.initChars = set(initChars)
-        if bodyChars :
+        if bodyChars:
             self.bodyCharsOrig = bodyChars
             self.bodyChars = set(bodyChars)
         else:
@@ -1710,7 +1843,8 @@ class Word(Token):
         self.maxSpecified = max > 0
 
         if min < 1:
-            raise ValueError("cannot specify a minimum length < 1; use Optional(Word()) if zero-length word is permitted")
+            raise ValueError(
+                "cannot specify a minimum length < 1; use Optional(Word()) if zero-length word is permitted")
 
         self.minLen = min
 
@@ -1728,7 +1862,7 @@ class Word(Token):
         self.mayIndexError = False
         self.asKeyword = asKeyword
 
-        if ' ' not in self.initCharsOrig+self.bodyCharsOrig and (min==1 and max==0 and exact==0):
+        if ' ' not in self.initCharsOrig + self.bodyCharsOrig and (min == 1 and max == 0 and exact == 0):
             if self.bodyCharsOrig == self.initCharsOrig:
                 self.reString = "[%s]+" % _escapeRegexRangeChars(self.initCharsOrig)
             elif len(self.bodyCharsOrig) == 1:
@@ -1740,22 +1874,22 @@ class Word(Token):
                                       (_escapeRegexRangeChars(self.initCharsOrig),
                                       _escapeRegexRangeChars(self.bodyCharsOrig),)
             if self.asKeyword:
-                self.reString = r"\b"+self.reString+r"\b"
+                self.reString = r"\b" + self.reString + r"\b"
             try:
-                self.re = re.compile( self.reString )
+                self.re = re.compile(self.reString)
             except:
                 self.re = None
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         if self.re:
-            result = self.re.match(instring,loc)
+            result = self.re.match(instring, loc)
             if not result:
                 raise ParseException(instring, loc, self.errmsg, self)
 
             loc = result.end()
             return loc, result.group()
 
-        if not(instring[ loc ] in self.initChars):
+        if not (instring[loc] in self.initChars):
             raise ParseException(instring, loc, self.errmsg, self)
 
         start = loc
@@ -1763,7 +1897,7 @@ class Word(Token):
         instrlen = len(instring)
         bodychars = self.bodyChars
         maxloc = start + self.maxLen
-        maxloc = min( maxloc, instrlen )
+        maxloc = min(maxloc, instrlen)
         while loc < maxloc and instring[loc] in bodychars:
             loc += 1
 
@@ -1773,7 +1907,7 @@ class Word(Token):
         if self.maxSpecified and loc < instrlen and instring[loc] in bodychars:
             throwException = True
         if self.asKeyword:
-            if (start>0 and instring[start-1] in bodychars) or (loc<instrlen and instring[loc] in bodychars):
+            if (start > 0 and instring[start - 1] in bodychars) or (loc < instrlen and instring[loc] in bodychars):
                 throwException = True
 
         if throwException:
@@ -1781,23 +1915,22 @@ class Word(Token):
 
         return loc, instring[start:loc]
 
-    def __str__( self ):
+    def __str__(self):
         try:
-            return super(Word,self).__str__()
+            return super(Word, self).__str__()
         except:
             pass
-
 
         if self.strRepr is None:
 
             def charsAsStr(s):
-                if len(s)>4:
-                    return s[:4]+"..."
+                if len(s) > 4:
+                    return s[:4] + "..."
                 else:
                     return s
 
-            if ( self.initCharsOrig != self.bodyCharsOrig ):
-                self.strRepr = "W:(%s,%s)" % ( charsAsStr(self.initCharsOrig), charsAsStr(self.bodyCharsOrig) )
+            if (self.initCharsOrig != self.bodyCharsOrig):
+                self.strRepr = "W:(%s,%s)" % (charsAsStr(self.initCharsOrig), charsAsStr(self.bodyCharsOrig))
             else:
                 self.strRepr = "W:(%s)" % charsAsStr(self.initCharsOrig)
 
@@ -1809,14 +1942,14 @@ class Regex(Token):
        Defined with string specifying the regular expression in a form recognized by the inbuilt Python re module.
     """
     compiledREtype = type(re.compile("[A-Z]"))
-    def __init__( self, pattern, flags=0):
+
+    def __init__(self, pattern, flags=0):
         """The parameters C{pattern} and C{flags} are passed to the C{re.compile()} function as-is. See the Python C{re} module for an explanation of the acceptable patterns and flags."""
-        super(Regex,self).__init__()
+        super(Regex, self).__init__()
 
         if isinstance(pattern, basestring):
             if len(pattern) == 0:
-                warnings.warn("null string passed to Regex; use Empty() instead",
-                        SyntaxWarning, stacklevel=2)
+                warnings.warn("null string passed to Regex; use Empty() instead", SyntaxWarning, stacklevel=2)
 
             self.pattern = pattern
             self.flags = flags
@@ -1825,8 +1958,7 @@ class Regex(Token):
                 self.re = re.compile(self.pattern, self.flags)
                 self.reString = self.pattern
             except sre_constants.error:
-                warnings.warn("invalid pattern (%s) passed to Regex" % pattern,
-                    SyntaxWarning, stacklevel=2)
+                warnings.warn("invalid pattern (%s) passed to Regex" % pattern, SyntaxWarning, stacklevel=2)
                 raise
 
         elif isinstance(pattern, Regex.compiledREtype):
@@ -1834,7 +1966,7 @@ class Regex(Token):
             self.pattern = \
             self.reString = str(pattern)
             self.flags = flags
-            
+
         else:
             raise ValueError("Regex may only be constructed with a string or a compiled RE object")
 
@@ -1843,8 +1975,8 @@ class Regex(Token):
         self.mayIndexError = False
         self.mayReturnEmpty = True
 
-    def parseImpl( self, instring, loc, doActions=True ):
-        result = self.re.match(instring,loc)
+    def parseImpl(self, instring, loc, doActions=True):
+        result = self.re.match(instring, loc)
         if not result:
             raise ParseException(instring, loc, self.errmsg, self)
 
@@ -1854,11 +1986,11 @@ class Regex(Token):
         if d:
             for k in d:
                 ret[k] = d[k]
-        return loc,ret
+        return loc, ret
 
-    def __str__( self ):
+    def __str__(self):
         try:
-            return super(Regex,self).__str__()
+            return super(Regex, self).__str__()
         except:
             pass
 
@@ -1871,7 +2003,9 @@ class Regex(Token):
 class QuotedString(Token):
     """Token for matching strings that are delimited by quoting characters.
     """
-    def __init__( self, quoteChar, escChar=None, escQuote=None, multiline=False, unquoteResults=True, endQuoteChar=None):
+
+    def __init__(self, quoteChar, escChar=None, escQuote=None, multiline=False, unquoteResults=True,
+                 endQuoteChar=None):
         """
            Defined with the following parameters:
             - quoteChar - string of one or more characters defining the quote delimiting string
@@ -1881,12 +2015,12 @@ class QuotedString(Token):
             - unquoteResults - boolean indicating whether the matched text should be unquoted (default=C{True})
             - endQuoteChar - string of one or more characters defining the end of the quote delimited string (default=C{None} => same as quoteChar)
         """
-        super(QuotedString,self).__init__()
+        super(QuotedString, self).__init__()
 
         # remove white space from quote chars - wont work anyway
         quoteChar = quoteChar.strip()
         if len(quoteChar) == 0:
-            warnings.warn("quoteChar cannot be the empty string",SyntaxWarning,stacklevel=2)
+            warnings.warn("quoteChar cannot be the empty string", SyntaxWarning, stacklevel=2)
             raise SyntaxError()
 
         if endQuoteChar is None:
@@ -1894,7 +2028,7 @@ class QuotedString(Token):
         else:
             endQuoteChar = endQuoteChar.strip()
             if len(endQuoteChar) == 0:
-                warnings.warn("endQuoteChar cannot be the empty string",SyntaxWarning,stacklevel=2)
+                warnings.warn("endQuoteChar cannot be the empty string", SyntaxWarning, stacklevel=2)
                 raise SyntaxError()
 
         self.quoteChar = quoteChar
@@ -1920,23 +2054,21 @@ class QuotedString(Token):
                   (escChar is not None and _escapeRegexRangeChars(escChar) or '') )
         if len(self.endQuoteChar) > 1:
             self.pattern += (
-                '|(?:' + ')|(?:'.join("%s[^%s]" % (re.escape(self.endQuoteChar[:i]),
-                                               _escapeRegexRangeChars(self.endQuoteChar[i]))
-                                    for i in range(len(self.endQuoteChar)-1,0,-1)) + ')'
-                )
+                '|(?:' + ')|(?:'.join("%s[^%s]" %
+                                      (re.escape(self.endQuoteChar[:i]), _escapeRegexRangeChars(self.endQuoteChar[i]))
+                                      for i in range(len(self.endQuoteChar) - 1, 0, -1)) + ')')
         if escQuote:
             self.pattern += (r'|(?:%s)' % re.escape(escQuote))
         if escChar:
             self.pattern += (r'|(?:%s.)' % re.escape(escChar))
-            self.escCharReplacePattern = re.escape(self.escChar)+"(.)"
+            self.escCharReplacePattern = re.escape(self.escChar) + "(.)"
         self.pattern += (r')*%s' % re.escape(self.endQuoteChar))
 
         try:
             self.re = re.compile(self.pattern, self.flags)
             self.reString = self.pattern
         except sre_constants.error:
-            warnings.warn("invalid pattern (%s) passed to Regex" % self.pattern,
-                SyntaxWarning, stacklevel=2)
+            warnings.warn("invalid pattern (%s) passed to Regex" % self.pattern, SyntaxWarning, stacklevel=2)
             raise
 
         self.name = _ustr(self)
@@ -1944,8 +2076,8 @@ class QuotedString(Token):
         self.mayIndexError = False
         self.mayReturnEmpty = True
 
-    def parseImpl( self, instring, loc, doActions=True ):
-        result = instring[loc] == self.firstQuoteChar and self.re.match(instring,loc) or None
+    def parseImpl(self, instring, loc, doActions=True):
+        result = instring[loc] == self.firstQuoteChar and self.re.match(instring, loc) or None
         if not result:
             raise ParseException(instring, loc, self.errmsg, self)
 
@@ -1957,10 +2089,10 @@ class QuotedString(Token):
             # strip off quotes
             ret = ret[self.quoteCharLen:-self.endQuoteCharLen]
 
-            if isinstance(ret,basestring):
+            if isinstance(ret, basestring):
                 # replace escaped characters
                 if self.escChar:
-                    ret = re.sub(self.escCharReplacePattern,"\g<1>",ret)
+                    ret = re.sub(self.escCharReplacePattern, "\g<1>", ret)
 
                 # replace escaped quotes
                 if self.escQuote:
@@ -1968,9 +2100,9 @@ class QuotedString(Token):
 
         return loc, ret
 
-    def __str__( self ):
+    def __str__(self):
         try:
-            return super(QuotedString,self).__str__()
+            return super(QuotedString, self).__str__()
         except:
             pass
 
@@ -1987,13 +2119,15 @@ class CharsNotIn(Token):
        minimum value < 1 is not valid); the default values for C{max} and C{exact}
        are 0, meaning no maximum or exact length restriction.
     """
-    def __init__( self, notChars, min=1, max=0, exact=0 ):
-        super(CharsNotIn,self).__init__()
+
+    def __init__(self, notChars, min=1, max=0, exact=0):
+        super(CharsNotIn, self).__init__()
         self.skipWhitespace = False
         self.notChars = notChars
 
         if min < 1:
-            raise ValueError("cannot specify a minimum length < 1; use Optional(CharsNotIn()) if zero-length char group is permitted")
+            raise ValueError(
+                "cannot specify a minimum length < 1; use Optional(CharsNotIn()) if zero-length char group is permitted")
 
         self.minLen = min
 
@@ -2008,17 +2142,17 @@ class CharsNotIn(Token):
 
         self.name = _ustr(self)
         self.errmsg = "Expected " + self.name
-        self.mayReturnEmpty = ( self.minLen == 0 )
+        self.mayReturnEmpty = (self.minLen == 0)
         self.mayIndexError = False
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         if instring[loc] in self.notChars:
             raise ParseException(instring, loc, self.errmsg, self)
 
         start = loc
         loc += 1
         notchars = self.notChars
-        maxlen = min( start+self.maxLen, len(instring) )
+        maxlen = min(start + self.maxLen, len(instring))
         while loc < maxlen and \
               (instring[loc] not in notchars):
             loc += 1
@@ -2028,7 +2162,7 @@ class CharsNotIn(Token):
 
         return loc, instring[start:loc]
 
-    def __str__( self ):
+    def __str__(self):
         try:
             return super(CharsNotIn, self).__str__()
         except:
@@ -2042,6 +2176,7 @@ class CharsNotIn(Token):
 
         return self.strRepr
 
+
 class White(Token):
     """Special matching class for matching whitespace.  Normally, whitespace is ignored
        by pyparsing grammars.  This class is included when some whitespace structures
@@ -2049,16 +2184,17 @@ class White(Token):
        matched; default is C{" \\t\\r\\n"}.  Also takes optional C{min}, C{max}, and C{exact} arguments,
        as defined for the C{L{Word}} class."""
     whiteStrs = {
-        " " : "<SPC>",
+        " ": "<SPC>",
         "\t": "<TAB>",
         "\n": "<LF>",
         "\r": "<CR>",
         "\f": "<FF>",
-        }
+    }
+
     def __init__(self, ws=" \t\r\n", min=1, max=0, exact=0):
-        super(White,self).__init__()
+        super(White, self).__init__()
         self.matchWhite = ws
-        self.setWhitespaceChars( "".join(c for c in self.whiteChars if c not in self.matchWhite) )
+        self.setWhitespaceChars("".join(c for c in self.whiteChars if c not in self.matchWhite))
         #~ self.leaveWhitespace()
         self.name = ("".join(White.whiteStrs[c] for c in self.matchWhite))
         self.mayReturnEmpty = True
@@ -2075,13 +2211,13 @@ class White(Token):
             self.maxLen = exact
             self.minLen = exact
 
-    def parseImpl( self, instring, loc, doActions=True ):
-        if not(instring[ loc ] in self.matchWhite):
+    def parseImpl(self, instring, loc, doActions=True):
+        if not (instring[loc] in self.matchWhite):
             raise ParseException(instring, loc, self.errmsg, self)
         start = loc
         loc += 1
         maxloc = start + self.maxLen
-        maxloc = min( maxloc, len(instring) )
+        maxloc = min(maxloc, len(instring))
         while loc < maxloc and instring[loc] in self.matchWhite:
             loc += 1
 
@@ -2092,101 +2228,111 @@ class White(Token):
 
 
 class _PositionToken(Token):
-    def __init__( self ):
-        super(_PositionToken,self).__init__()
-        self.name=self.__class__.__name__
+    def __init__(self):
+        super(_PositionToken, self).__init__()
+        self.name = self.__class__.__name__
         self.mayReturnEmpty = True
         self.mayIndexError = False
 
+
 class GoToColumn(_PositionToken):
     """Token to advance to a specific column of input text; useful for tabular report scraping."""
-    def __init__( self, colno ):
-        super(GoToColumn,self).__init__()
+
+    def __init__(self, colno):
+        super(GoToColumn, self).__init__()
         self.col = colno
 
-    def preParse( self, instring, loc ):
-        if col(loc,instring) != self.col:
+    def preParse(self, instring, loc):
+        if col(loc, instring) != self.col:
             instrlen = len(instring)
             if self.ignoreExprs:
-                loc = self._skipIgnorables( instring, loc )
-            while loc < instrlen and instring[loc].isspace() and col( loc, instring ) != self.col :
+                loc = self._skipIgnorables(instring, loc)
+            while loc < instrlen and instring[loc].isspace() and col(loc, instring) != self.col:
                 loc += 1
         return loc
 
-    def parseImpl( self, instring, loc, doActions=True ):
-        thiscol = col( loc, instring )
+    def parseImpl(self, instring, loc, doActions=True):
+        thiscol = col(loc, instring)
         if thiscol > self.col:
-            raise ParseException( instring, loc, "Text not in expected column", self )
+            raise ParseException(instring, loc, "Text not in expected column", self)
         newloc = loc + self.col - thiscol
-        ret = instring[ loc: newloc ]
+        ret = instring[loc:newloc]
         return newloc, ret
+
 
 class LineStart(_PositionToken):
     """Matches if current position is at the beginning of a line within the parse string"""
-    def __init__( self ):
-        super(LineStart,self).__init__()
-        self.setWhitespaceChars( ParserElement.DEFAULT_WHITE_CHARS.replace("\n","") )
+
+    def __init__(self):
+        super(LineStart, self).__init__()
+        self.setWhitespaceChars(ParserElement.DEFAULT_WHITE_CHARS.replace("\n", ""))
         self.errmsg = "Expected start of line"
 
-    def preParse( self, instring, loc ):
-        preloc = super(LineStart,self).preParse(instring,loc)
+    def preParse(self, instring, loc):
+        preloc = super(LineStart, self).preParse(instring, loc)
         if instring[preloc] == "\n":
             loc += 1
         return loc
 
-    def parseImpl( self, instring, loc, doActions=True ):
-        if not( loc==0 or
-            (loc == self.preParse( instring, 0 )) or
-            (instring[loc-1] == "\n") ): #col(loc, instring) != 1:
+    def parseImpl(self, instring, loc, doActions=True):
+        if not (loc == 0 or (loc == self.preParse(instring, 0)) or
+                (instring[loc - 1] == "\n")):  #col(loc, instring) != 1:
             raise ParseException(instring, loc, self.errmsg, self)
         return loc, []
+
 
 class LineEnd(_PositionToken):
     """Matches if current position is at the end of a line within the parse string"""
-    def __init__( self ):
-        super(LineEnd,self).__init__()
-        self.setWhitespaceChars( ParserElement.DEFAULT_WHITE_CHARS.replace("\n","") )
+
+    def __init__(self):
+        super(LineEnd, self).__init__()
+        self.setWhitespaceChars(ParserElement.DEFAULT_WHITE_CHARS.replace("\n", ""))
         self.errmsg = "Expected end of line"
 
-    def parseImpl( self, instring, loc, doActions=True ):
-        if loc<len(instring):
+    def parseImpl(self, instring, loc, doActions=True):
+        if loc < len(instring):
             if instring[loc] == "\n":
-                return loc+1, "\n"
+                return loc + 1, "\n"
             else:
                 raise ParseException(instring, loc, self.errmsg, self)
         elif loc == len(instring):
-            return loc+1, []
+            return loc + 1, []
         else:
             raise ParseException(instring, loc, self.errmsg, self)
 
+
 class StringStart(_PositionToken):
     """Matches if current position is at the beginning of the parse string"""
-    def __init__( self ):
-        super(StringStart,self).__init__()
+
+    def __init__(self):
+        super(StringStart, self).__init__()
         self.errmsg = "Expected start of text"
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         if loc != 0:
             # see if entire string up to here is just whitespace and ignoreables
-            if loc != self.preParse( instring, 0 ):
+            if loc != self.preParse(instring, 0):
                 raise ParseException(instring, loc, self.errmsg, self)
         return loc, []
 
+
 class StringEnd(_PositionToken):
     """Matches if current position is at the end of the parse string"""
-    def __init__( self ):
-        super(StringEnd,self).__init__()
+
+    def __init__(self):
+        super(StringEnd, self).__init__()
         self.errmsg = "Expected end of text"
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         if loc < len(instring):
             raise ParseException(instring, loc, self.errmsg, self)
         elif loc == len(instring):
-            return loc+1, []
+            return loc + 1, []
         elif loc > len(instring):
             return loc, []
         else:
             raise ParseException(instring, loc, self.errmsg, self)
+
 
 class WordStart(_PositionToken):
     """Matches if the current position is at the beginning of a Word, and
@@ -2195,17 +2341,18 @@ class WordStart(_PositionToken):
        use C{WordStart(alphanums)}. C{WordStart} will also match at the beginning of
        the string being parsed, or at the beginning of a line.
     """
-    def __init__(self, wordChars = printables):
-        super(WordStart,self).__init__()
+
+    def __init__(self, wordChars=printables):
+        super(WordStart, self).__init__()
         self.wordChars = set(wordChars)
         self.errmsg = "Not at the start of a word"
 
-    def parseImpl(self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         if loc != 0:
-            if (instring[loc-1] in self.wordChars or
-                instring[loc] not in self.wordChars):
+            if (instring[loc - 1] in self.wordChars or instring[loc] not in self.wordChars):
                 raise ParseException(instring, loc, self.errmsg, self)
         return loc, []
+
 
 class WordEnd(_PositionToken):
     """Matches if the current position is at the end of a Word, and
@@ -2214,83 +2361,84 @@ class WordEnd(_PositionToken):
        use C{WordEnd(alphanums)}. C{WordEnd} will also match at the end of
        the string being parsed, or at the end of a line.
     """
-    def __init__(self, wordChars = printables):
-        super(WordEnd,self).__init__()
+
+    def __init__(self, wordChars=printables):
+        super(WordEnd, self).__init__()
         self.wordChars = set(wordChars)
         self.skipWhitespace = False
         self.errmsg = "Not at the end of a word"
 
-    def parseImpl(self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         instrlen = len(instring)
-        if instrlen>0 and loc<instrlen:
-            if (instring[loc] in self.wordChars or
-                instring[loc-1] not in self.wordChars):
+        if instrlen > 0 and loc < instrlen:
+            if (instring[loc] in self.wordChars or instring[loc - 1] not in self.wordChars):
                 raise ParseException(instring, loc, self.errmsg, self)
         return loc, []
 
 
 class ParseExpression(ParserElement):
     """Abstract subclass of ParserElement, for combining and post-processing parsed tokens."""
-    def __init__( self, exprs, savelist = False ):
-        super(ParseExpression,self).__init__(savelist)
-        if isinstance( exprs, _generatorType ):
+
+    def __init__(self, exprs, savelist=False):
+        super(ParseExpression, self).__init__(savelist)
+        if isinstance(exprs, _generatorType):
             exprs = list(exprs)
 
-        if isinstance( exprs, basestring ):
-            self.exprs = [ Literal( exprs ) ]
-        elif isinstance( exprs, collections.Sequence ):
+        if isinstance(exprs, basestring):
+            self.exprs = [Literal(exprs)]
+        elif isinstance(exprs, collections.Sequence):
             # if sequence of strings provided, wrap with Literal
             if all(isinstance(expr, basestring) for expr in exprs):
                 exprs = map(Literal, exprs)
             self.exprs = list(exprs)
         else:
             try:
-                self.exprs = list( exprs )
+                self.exprs = list(exprs)
             except TypeError:
-                self.exprs = [ exprs ]
+                self.exprs = [exprs]
         self.callPreparse = False
 
-    def __getitem__( self, i ):
+    def __getitem__(self, i):
         return self.exprs[i]
 
-    def append( self, other ):
-        self.exprs.append( other )
+    def append(self, other):
+        self.exprs.append(other)
         self.strRepr = None
         return self
 
-    def leaveWhitespace( self ):
+    def leaveWhitespace(self):
         """Extends C{leaveWhitespace} defined in base class, and also invokes C{leaveWhitespace} on
            all contained expressions."""
         self.skipWhitespace = False
-        self.exprs = [ e.copy() for e in self.exprs ]
+        self.exprs = [e.copy() for e in self.exprs]
         for e in self.exprs:
             e.leaveWhitespace()
         return self
 
-    def ignore( self, other ):
-        if isinstance( other, Suppress ):
+    def ignore(self, other):
+        if isinstance(other, Suppress):
             if other not in self.ignoreExprs:
-                super( ParseExpression, self).ignore( other )
+                super(ParseExpression, self).ignore(other)
                 for e in self.exprs:
-                    e.ignore( self.ignoreExprs[-1] )
+                    e.ignore(self.ignoreExprs[-1])
         else:
-            super( ParseExpression, self).ignore( other )
+            super(ParseExpression, self).ignore(other)
             for e in self.exprs:
-                e.ignore( self.ignoreExprs[-1] )
+                e.ignore(self.ignoreExprs[-1])
         return self
 
-    def __str__( self ):
+    def __str__(self):
         try:
-            return super(ParseExpression,self).__str__()
+            return super(ParseExpression, self).__str__()
         except:
             pass
 
         if self.strRepr is None:
-            self.strRepr = "%s:(%s)" % ( self.__class__.__name__, _ustr(self.exprs) )
+            self.strRepr = "%s:(%s)" % (self.__class__.__name__, _ustr(self.exprs))
         return self.strRepr
 
-    def streamline( self ):
-        super(ParseExpression,self).streamline()
+    def streamline(self):
+        super(ParseExpression, self).streamline()
 
         for e in self.exprs:
             e.streamline()
@@ -2298,43 +2446,40 @@ class ParseExpression(ParserElement):
         # collapse nested And's of the form And( And( And( a,b), c), d) to And( a,b,c,d )
         # but only if there are no parse actions or resultsNames on the nested And's
         # (likewise for Or's and MatchFirst's)
-        if ( len(self.exprs) == 2 ):
+        if (len(self.exprs) == 2):
             other = self.exprs[0]
-            if ( isinstance( other, self.__class__ ) and
-                  not(other.parseAction) and
-                  other.resultsName is None and
-                  not other.debug ):
-                self.exprs = other.exprs[:] + [ self.exprs[1] ]
+            if (isinstance(other, self.__class__) and not (other.parseAction) and other.resultsName is None and
+                    not other.debug):
+                self.exprs = other.exprs[:] + [self.exprs[1]]
                 self.strRepr = None
                 self.mayReturnEmpty |= other.mayReturnEmpty
-                self.mayIndexError  |= other.mayIndexError
+                self.mayIndexError |= other.mayIndexError
 
             other = self.exprs[-1]
-            if ( isinstance( other, self.__class__ ) and
-                  not(other.parseAction) and
-                  other.resultsName is None and
-                  not other.debug ):
+            if (isinstance(other, self.__class__) and not (other.parseAction) and other.resultsName is None and
+                    not other.debug):
                 self.exprs = self.exprs[:-1] + other.exprs[:]
                 self.strRepr = None
                 self.mayReturnEmpty |= other.mayReturnEmpty
-                self.mayIndexError  |= other.mayIndexError
+                self.mayIndexError |= other.mayIndexError
 
         return self
 
-    def setResultsName( self, name, listAllMatches=False ):
-        ret = super(ParseExpression,self).setResultsName(name,listAllMatches)
+    def setResultsName(self, name, listAllMatches=False):
+        ret = super(ParseExpression, self).setResultsName(name, listAllMatches)
         return ret
 
-    def validate( self, validateTrace=[] ):
-        tmp = validateTrace[:]+[self]
+    def validate(self, validateTrace=[]):
+        tmp = validateTrace[:] + [self]
         for e in self.exprs:
             e.validate(tmp)
-        self.checkRecursion( [] )
-        
+        self.checkRecursion([])
+
     def copy(self):
-        ret = super(ParseExpression,self).copy()
+        ret = super(ParseExpression, self).copy()
         ret.exprs = [e.copy() for e in self.exprs]
         return ret
+
 
 class And(ParseExpression):
     """Requires all given C{ParseExpression}s to be found in the given order.
@@ -2344,21 +2489,21 @@ class And(ParseExpression):
 
     class _ErrorStop(Empty):
         def __init__(self, *args, **kwargs):
-            super(And._ErrorStop,self).__init__(*args, **kwargs)
+            super(And._ErrorStop, self).__init__(*args, **kwargs)
             self.name = '-'
             self.leaveWhitespace()
 
-    def __init__( self, exprs, savelist = True ):
-        super(And,self).__init__(exprs, savelist)
+    def __init__(self, exprs, savelist=True):
+        super(And, self).__init__(exprs, savelist)
         self.mayReturnEmpty = all(e.mayReturnEmpty for e in self.exprs)
-        self.setWhitespaceChars( self.exprs[0].whiteChars )
+        self.setWhitespaceChars(self.exprs[0].whiteChars)
         self.skipWhitespace = self.exprs[0].skipWhitespace
         self.callPreparse = True
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         # pass False as last arg to _parse for first element, since we already
         # pre-parsed the string as part of our And pre-parsing
-        loc, resultlist = self.exprs[0]._parse( instring, loc, doActions, callPreParse=False )
+        loc, resultlist = self.exprs[0]._parse(instring, loc, doActions, callPreParse=False)
         errorStop = False
         for e in self.exprs[1:]:
             if isinstance(e, And._ErrorStop):
@@ -2366,34 +2511,34 @@ class And(ParseExpression):
                 continue
             if errorStop:
                 try:
-                    loc, exprtokens = e._parse( instring, loc, doActions )
+                    loc, exprtokens = e._parse(instring, loc, doActions)
                 except ParseSyntaxException:
                     raise
                 except ParseBaseException as pe:
                     pe.__traceback__ = None
                     raise ParseSyntaxException(pe)
                 except IndexError:
-                    raise ParseSyntaxException( ParseException(instring, len(instring), self.errmsg, self) )
+                    raise ParseSyntaxException(ParseException(instring, len(instring), self.errmsg, self))
             else:
-                loc, exprtokens = e._parse( instring, loc, doActions )
+                loc, exprtokens = e._parse(instring, loc, doActions)
             if exprtokens or exprtokens.haskeys():
                 resultlist += exprtokens
         return loc, resultlist
 
-    def __iadd__(self, other ):
-        if isinstance( other, basestring ):
-            other = Literal( other )
-        return self.append( other ) #And( [ self, other ] )
+    def __iadd__(self, other):
+        if isinstance(other, basestring):
+            other = Literal(other)
+        return self.append(other)  #And( [ self, other ] )
 
-    def checkRecursion( self, parseElementList ):
-        subRecCheckList = parseElementList[:] + [ self ]
+    def checkRecursion(self, parseElementList):
+        subRecCheckList = parseElementList[:] + [self]
         for e in self.exprs:
-            e.checkRecursion( subRecCheckList )
+            e.checkRecursion(subRecCheckList)
             if not e.mayReturnEmpty:
                 break
 
-    def __str__( self ):
-        if hasattr(self,"name"):
+    def __str__(self):
+        if hasattr(self, "name"):
             return self.name
 
         if self.strRepr is None:
@@ -2407,20 +2552,21 @@ class Or(ParseExpression):
        If two expressions match, the expression that matches the longest string will be used.
        May be constructed using the C{'^'} operator.
     """
-    def __init__( self, exprs, savelist = False ):
-        super(Or,self).__init__(exprs, savelist)
+
+    def __init__(self, exprs, savelist=False):
+        super(Or, self).__init__(exprs, savelist)
         if self.exprs:
             self.mayReturnEmpty = any(e.mayReturnEmpty for e in self.exprs)
         else:
             self.mayReturnEmpty = True
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         maxExcLoc = -1
         maxMatchLoc = -1
         maxException = None
         for e in self.exprs:
             try:
-                loc2 = e.tryParse( instring, loc )
+                loc2 = e.tryParse(instring, loc)
             except ParseException as err:
                 err.__traceback__ = None
                 if err.loc > maxExcLoc:
@@ -2428,7 +2574,7 @@ class Or(ParseExpression):
                     maxExcLoc = err.loc
             except IndexError:
                 if len(instring) > maxExcLoc:
-                    maxException = ParseException(instring,len(instring),e.errmsg,self)
+                    maxException = ParseException(instring, len(instring), e.errmsg, self)
                     maxExcLoc = len(instring)
             else:
                 if loc2 > maxMatchLoc:
@@ -2441,15 +2587,15 @@ class Or(ParseExpression):
             else:
                 raise ParseException(instring, loc, "no defined alternatives to match", self)
 
-        return maxMatchExp._parse( instring, loc, doActions )
+        return maxMatchExp._parse(instring, loc, doActions)
 
-    def __ixor__(self, other ):
-        if isinstance( other, basestring ):
-            other = ParserElement.literalStringClass( other )
-        return self.append( other ) #Or( [ self, other ] )
+    def __ixor__(self, other):
+        if isinstance(other, basestring):
+            other = ParserElement.literalStringClass(other)
+        return self.append(other)  #Or( [ self, other ] )
 
-    def __str__( self ):
-        if hasattr(self,"name"):
+    def __str__(self):
+        if hasattr(self, "name"):
             return self.name
 
         if self.strRepr is None:
@@ -2457,10 +2603,10 @@ class Or(ParseExpression):
 
         return self.strRepr
 
-    def checkRecursion( self, parseElementList ):
-        subRecCheckList = parseElementList[:] + [ self ]
+    def checkRecursion(self, parseElementList):
+        subRecCheckList = parseElementList[:] + [self]
         for e in self.exprs:
-            e.checkRecursion( subRecCheckList )
+            e.checkRecursion(subRecCheckList)
 
 
 class MatchFirst(ParseExpression):
@@ -2468,19 +2614,20 @@ class MatchFirst(ParseExpression):
        If two expressions match, the first one listed is the one that will match.
        May be constructed using the C{'|'} operator.
     """
-    def __init__( self, exprs, savelist = False ):
-        super(MatchFirst,self).__init__(exprs, savelist)
+
+    def __init__(self, exprs, savelist=False):
+        super(MatchFirst, self).__init__(exprs, savelist)
         if self.exprs:
             self.mayReturnEmpty = any(e.mayReturnEmpty for e in self.exprs)
         else:
             self.mayReturnEmpty = True
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         maxExcLoc = -1
         maxException = None
         for e in self.exprs:
             try:
-                ret = e._parse( instring, loc, doActions )
+                ret = e._parse(instring, loc, doActions)
                 return ret
             except ParseException as err:
                 if err.loc > maxExcLoc:
@@ -2488,7 +2635,7 @@ class MatchFirst(ParseExpression):
                     maxExcLoc = err.loc
             except IndexError:
                 if len(instring) > maxExcLoc:
-                    maxException = ParseException(instring,len(instring),e.errmsg,self)
+                    maxException = ParseException(instring, len(instring), e.errmsg, self)
                     maxExcLoc = len(instring)
 
         # only got here if no expression matched, raise exception for match that made it the furthest
@@ -2498,13 +2645,13 @@ class MatchFirst(ParseExpression):
             else:
                 raise ParseException(instring, loc, "no defined alternatives to match", self)
 
-    def __ior__(self, other ):
-        if isinstance( other, basestring ):
-            other = ParserElement.literalStringClass( other )
-        return self.append( other ) #MatchFirst( [ self, other ] )
+    def __ior__(self, other):
+        if isinstance(other, basestring):
+            other = ParserElement.literalStringClass(other)
+        return self.append(other)  #MatchFirst( [ self, other ] )
 
-    def __str__( self ):
-        if hasattr(self,"name"):
+    def __str__(self):
+        if hasattr(self, "name"):
             return self.name
 
         if self.strRepr is None:
@@ -2512,10 +2659,10 @@ class MatchFirst(ParseExpression):
 
         return self.strRepr
 
-    def checkRecursion( self, parseElementList ):
-        subRecCheckList = parseElementList[:] + [ self ]
+    def checkRecursion(self, parseElementList):
+        subRecCheckList = parseElementList[:] + [self]
         for e in self.exprs:
-            e.checkRecursion( subRecCheckList )
+            e.checkRecursion(subRecCheckList)
 
 
 class Each(ParseExpression):
@@ -2523,25 +2670,26 @@ class Each(ParseExpression):
        Expressions may be separated by whitespace.
        May be constructed using the C{'&'} operator.
     """
-    def __init__( self, exprs, savelist = True ):
-        super(Each,self).__init__(exprs, savelist)
+
+    def __init__(self, exprs, savelist=True):
+        super(Each, self).__init__(exprs, savelist)
         self.mayReturnEmpty = all(e.mayReturnEmpty for e in self.exprs)
         self.skipWhitespace = True
         self.initExprGroups = True
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         if self.initExprGroups:
-            opt1 = [ e.expr for e in self.exprs if isinstance(e,Optional) ]
-            opt2 = [ e for e in self.exprs if e.mayReturnEmpty and e not in opt1 ]
+            opt1 = [e.expr for e in self.exprs if isinstance(e, Optional)]
+            opt2 = [e for e in self.exprs if e.mayReturnEmpty and e not in opt1]
             self.optionals = opt1 + opt2
-            self.multioptionals = [ e.expr for e in self.exprs if isinstance(e,ZeroOrMore) ]
-            self.multirequired = [ e.expr for e in self.exprs if isinstance(e,OneOrMore) ]
-            self.required = [ e for e in self.exprs if not isinstance(e,(Optional,ZeroOrMore,OneOrMore)) ]
+            self.multioptionals = [e.expr for e in self.exprs if isinstance(e, ZeroOrMore)]
+            self.multirequired = [e.expr for e in self.exprs if isinstance(e, OneOrMore)]
+            self.required = [e for e in self.exprs if not isinstance(e, (Optional, ZeroOrMore, OneOrMore))]
             self.required += self.multirequired
             self.initExprGroups = False
         tmpLoc = loc
         tmpReqd = self.required[:]
-        tmpOpt  = self.optionals[:]
+        tmpOpt = self.optionals[:]
         matchOrder = []
 
         keepMatching = True
@@ -2550,7 +2698,7 @@ class Each(ParseExpression):
             failed = []
             for e in tmpExprs:
                 try:
-                    tmpLoc = e.tryParse( instring, tmpLoc )
+                    tmpLoc = e.tryParse(instring, tmpLoc)
                 except ParseException:
                     failed.append(e)
                 else:
@@ -2564,14 +2712,14 @@ class Each(ParseExpression):
 
         if tmpReqd:
             missing = ", ".join(_ustr(e) for e in tmpReqd)
-            raise ParseException(instring,loc,"Missing one or more required elements (%s)" % missing )
+            raise ParseException(instring, loc, "Missing one or more required elements (%s)" % missing)
 
         # add any unmatched Optionals, in case they have default values defined
-        matchOrder += [e for e in self.exprs if isinstance(e,Optional) and e.expr in tmpOpt]
+        matchOrder += [e for e in self.exprs if isinstance(e, Optional) and e.expr in tmpOpt]
 
         resultlist = []
         for e in matchOrder:
-            loc,results = e._parse(instring,loc,doActions)
+            loc, results = e._parse(instring, loc, doActions)
             resultlist.append(results)
 
         finalResults = ParseResults([])
@@ -2583,12 +2731,12 @@ class Each(ParseExpression):
                     tmp += ParseResults(r[k])
                     dups[k] = tmp
             finalResults += ParseResults(r)
-            for k,v in dups.items():
+            for k, v in dups.items():
                 finalResults[k] = v
         return loc, finalResults
 
-    def __str__( self ):
-        if hasattr(self,"name"):
+    def __str__(self):
+        if hasattr(self, "name"):
             return self.name
 
         if self.strRepr is None:
@@ -2596,81 +2744,82 @@ class Each(ParseExpression):
 
         return self.strRepr
 
-    def checkRecursion( self, parseElementList ):
-        subRecCheckList = parseElementList[:] + [ self ]
+    def checkRecursion(self, parseElementList):
+        subRecCheckList = parseElementList[:] + [self]
         for e in self.exprs:
-            e.checkRecursion( subRecCheckList )
+            e.checkRecursion(subRecCheckList)
 
 
 class ParseElementEnhance(ParserElement):
     """Abstract subclass of C{ParserElement}, for combining and post-processing parsed tokens."""
-    def __init__( self, expr, savelist=False ):
-        super(ParseElementEnhance,self).__init__(savelist)
-        if isinstance( expr, basestring ):
+
+    def __init__(self, expr, savelist=False):
+        super(ParseElementEnhance, self).__init__(savelist)
+        if isinstance(expr, basestring):
             expr = Literal(expr)
         self.expr = expr
         self.strRepr = None
         if expr is not None:
             self.mayIndexError = expr.mayIndexError
             self.mayReturnEmpty = expr.mayReturnEmpty
-            self.setWhitespaceChars( expr.whiteChars )
+            self.setWhitespaceChars(expr.whiteChars)
             self.skipWhitespace = expr.skipWhitespace
             self.saveAsList = expr.saveAsList
             self.callPreparse = expr.callPreparse
             self.ignoreExprs.extend(expr.ignoreExprs)
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         if self.expr is not None:
-            return self.expr._parse( instring, loc, doActions, callPreParse=False )
+            return self.expr._parse(instring, loc, doActions, callPreParse=False)
         else:
-            raise ParseException("",loc,self.errmsg,self)
+            raise ParseException("", loc, self.errmsg, self)
 
-    def leaveWhitespace( self ):
+    def leaveWhitespace(self):
         self.skipWhitespace = False
         self.expr = self.expr.copy()
         if self.expr is not None:
             self.expr.leaveWhitespace()
         return self
 
-    def ignore( self, other ):
-        if isinstance( other, Suppress ):
+    def ignore(self, other):
+        if isinstance(other, Suppress):
             if other not in self.ignoreExprs:
-                super( ParseElementEnhance, self).ignore( other )
+                super(ParseElementEnhance, self).ignore(other)
                 if self.expr is not None:
-                    self.expr.ignore( self.ignoreExprs[-1] )
+                    self.expr.ignore(self.ignoreExprs[-1])
         else:
-            super( ParseElementEnhance, self).ignore( other )
+            super(ParseElementEnhance, self).ignore(other)
             if self.expr is not None:
-                self.expr.ignore( self.ignoreExprs[-1] )
+                self.expr.ignore(self.ignoreExprs[-1])
         return self
 
-    def streamline( self ):
-        super(ParseElementEnhance,self).streamline()
+    def streamline(self):
+        super(ParseElementEnhance, self).streamline()
         if self.expr is not None:
             self.expr.streamline()
         return self
 
-    def checkRecursion( self, parseElementList ):
+    def checkRecursion(self, parseElementList):
         if self in parseElementList:
-            raise RecursiveGrammarException( parseElementList+[self] )
-        subRecCheckList = parseElementList[:] + [ self ]
+            raise RecursiveGrammarException(parseElementList + [self])
+        subRecCheckList = parseElementList[:] + [self]
         if self.expr is not None:
-            self.expr.checkRecursion( subRecCheckList )
+            self.expr.checkRecursion(subRecCheckList)
 
-    def validate( self, validateTrace=[] ):
-        tmp = validateTrace[:]+[self]
+    def validate(self, validateTrace=[]):
+        tmp = validateTrace[:] + [self]
         if self.expr is not None:
             self.expr.validate(tmp)
-        self.checkRecursion( [] )
+        self.checkRecursion([])
 
-    def __str__( self ):
+    def __str__(self):
         try:
-            return super(ParseElementEnhance,self).__str__()
+            return super(ParseElementEnhance, self).__str__()
         except:
             pass
 
         if self.strRepr is None and self.expr is not None:
-            self.strRepr = "%s:(%s)" % ( self.__class__.__name__, _ustr(self.expr) )
+            self.strRepr = "%s:(%s)" % (self.__class__.__name__, _ustr(self.expr))
         return self.strRepr
 
 
@@ -2679,12 +2828,13 @@ class FollowedBy(ParseElementEnhance):
     does *not* advance the parsing position within the input string, it only
     verifies that the specified parse expression matches at the current
     position.  C{FollowedBy} always returns a null token list."""
-    def __init__( self, expr ):
-        super(FollowedBy,self).__init__(expr)
+
+    def __init__(self, expr):
+        super(FollowedBy, self).__init__(expr)
         self.mayReturnEmpty = True
 
-    def parseImpl( self, instring, loc, doActions=True ):
-        self.expr.tryParse( instring, loc )
+    def parseImpl(self, instring, loc, doActions=True):
+        self.expr.tryParse(instring, loc)
         return loc, []
 
 
@@ -2694,24 +2844,25 @@ class NotAny(ParseElementEnhance):
     verifies that the specified parse expression does *not* match at the current
     position.  Also, C{NotAny} does *not* skip over leading whitespace. C{NotAny}
     always returns a null token list.  May be constructed using the '~' operator."""
-    def __init__( self, expr ):
-        super(NotAny,self).__init__(expr)
+
+    def __init__(self, expr):
+        super(NotAny, self).__init__(expr)
         #~ self.leaveWhitespace()
         self.skipWhitespace = False  # do NOT use self.leaveWhitespace(), don't want to propagate to exprs
         self.mayReturnEmpty = True
-        self.errmsg = "Found unwanted token, "+_ustr(self.expr)
+        self.errmsg = "Found unwanted token, " + _ustr(self.expr)
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         try:
-            self.expr.tryParse( instring, loc )
-        except (ParseException,IndexError):
+            self.expr.tryParse(instring, loc)
+        except (ParseException, IndexError):
             pass
         else:
             raise ParseException(instring, loc, self.errmsg, self)
         return loc, []
 
-    def __str__( self ):
-        if hasattr(self,"name"):
+    def __str__(self):
+        if hasattr(self, "name"):
             return self.name
 
         if self.strRepr is None:
@@ -2722,30 +2873,31 @@ class NotAny(ParseElementEnhance):
 
 class ZeroOrMore(ParseElementEnhance):
     """Optional repetition of zero or more of the given expression."""
-    def __init__( self, expr ):
-        super(ZeroOrMore,self).__init__(expr)
+
+    def __init__(self, expr):
+        super(ZeroOrMore, self).__init__(expr)
         self.mayReturnEmpty = True
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         tokens = []
         try:
-            loc, tokens = self.expr._parse( instring, loc, doActions, callPreParse=False )
-            hasIgnoreExprs = ( len(self.ignoreExprs) > 0 )
+            loc, tokens = self.expr._parse(instring, loc, doActions, callPreParse=False)
+            hasIgnoreExprs = (len(self.ignoreExprs) > 0)
             while 1:
                 if hasIgnoreExprs:
-                    preloc = self._skipIgnorables( instring, loc )
+                    preloc = self._skipIgnorables(instring, loc)
                 else:
                     preloc = loc
-                loc, tmptokens = self.expr._parse( instring, preloc, doActions )
+                loc, tmptokens = self.expr._parse(instring, preloc, doActions)
                 if tmptokens or tmptokens.haskeys():
                     tokens += tmptokens
-        except (ParseException,IndexError):
+        except (ParseException, IndexError):
             pass
 
         return loc, tokens
 
-    def __str__( self ):
-        if hasattr(self,"name"):
+    def __str__(self):
+        if hasattr(self, "name"):
             return self.name
 
         if self.strRepr is None:
@@ -2753,34 +2905,35 @@ class ZeroOrMore(ParseElementEnhance):
 
         return self.strRepr
 
-    def setResultsName( self, name, listAllMatches=False ):
-        ret = super(ZeroOrMore,self).setResultsName(name,listAllMatches)
+    def setResultsName(self, name, listAllMatches=False):
+        ret = super(ZeroOrMore, self).setResultsName(name, listAllMatches)
         ret.saveAsList = True
         return ret
 
 
 class OneOrMore(ParseElementEnhance):
     """Repetition of one or more of the given expression."""
-    def parseImpl( self, instring, loc, doActions=True ):
+
+    def parseImpl(self, instring, loc, doActions=True):
         # must be at least one
-        loc, tokens = self.expr._parse( instring, loc, doActions, callPreParse=False )
+        loc, tokens = self.expr._parse(instring, loc, doActions, callPreParse=False)
         try:
-            hasIgnoreExprs = ( len(self.ignoreExprs) > 0 )
+            hasIgnoreExprs = (len(self.ignoreExprs) > 0)
             while 1:
                 if hasIgnoreExprs:
-                    preloc = self._skipIgnorables( instring, loc )
+                    preloc = self._skipIgnorables(instring, loc)
                 else:
                     preloc = loc
-                loc, tmptokens = self.expr._parse( instring, preloc, doActions )
+                loc, tmptokens = self.expr._parse(instring, preloc, doActions)
                 if tmptokens or tmptokens.haskeys():
                     tokens += tmptokens
-        except (ParseException,IndexError):
+        except (ParseException, IndexError):
             pass
 
         return loc, tokens
 
-    def __str__( self ):
-        if hasattr(self,"name"):
+    def __str__(self):
+        if hasattr(self, "name"):
             return self.name
 
         if self.strRepr is None:
@@ -2788,45 +2941,52 @@ class OneOrMore(ParseElementEnhance):
 
         return self.strRepr
 
-    def setResultsName( self, name, listAllMatches=False ):
-        ret = super(OneOrMore,self).setResultsName(name,listAllMatches)
+    def setResultsName(self, name, listAllMatches=False):
+        ret = super(OneOrMore, self).setResultsName(name, listAllMatches)
         ret.saveAsList = True
         return ret
+
 
 class _NullToken(object):
     def __bool__(self):
         return False
+
     __nonzero__ = __bool__
+
     def __str__(self):
         return ""
 
+
 _optionalNotMatched = _NullToken()
+
+
 class Optional(ParseElementEnhance):
     """Optional matching of the given expression.
        A default return string can also be specified, if the optional expression
        is not found.
     """
-    def __init__( self, expr, default=_optionalNotMatched ):
-        super(Optional,self).__init__( expr, savelist=False )
+
+    def __init__(self, expr, default=_optionalNotMatched):
+        super(Optional, self).__init__(expr, savelist=False)
         self.defaultValue = default
         self.mayReturnEmpty = True
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         try:
-            loc, tokens = self.expr._parse( instring, loc, doActions, callPreParse=False )
-        except (ParseException,IndexError):
+            loc, tokens = self.expr._parse(instring, loc, doActions, callPreParse=False)
+        except (ParseException, IndexError):
             if self.defaultValue is not _optionalNotMatched:
                 if self.expr.resultsName:
-                    tokens = ParseResults([ self.defaultValue ])
+                    tokens = ParseResults([self.defaultValue])
                     tokens[self.expr.resultsName] = self.defaultValue
                 else:
-                    tokens = [ self.defaultValue ]
+                    tokens = [self.defaultValue]
             else:
                 tokens = []
         return loc, tokens
 
-    def __str__( self ):
-        if hasattr(self,"name"):
+    def __str__(self):
+        if hasattr(self, "name"):
             return self.name
 
         if self.strRepr is None:
@@ -2842,8 +3002,9 @@ class SkipTo(ParseElementEnhance):
        argument is used to define grammars (typically quoted strings and comments) that
        might contain false matches.
     """
-    def __init__( self, other, include=False, ignore=None, failOn=None ):
-        super( SkipTo, self ).__init__( other )
+
+    def __init__(self, other, include=False, ignore=None, failOn=None):
+        super(SkipTo, self).__init__(other)
         self.ignoreExpr = ignore
         self.mayReturnEmpty = True
         self.mayIndexError = False
@@ -2853,9 +3014,9 @@ class SkipTo(ParseElementEnhance):
             self.failOn = Literal(failOn)
         else:
             self.failOn = failOn
-        self.errmsg = "No match found for "+_ustr(self.expr)
+        self.errmsg = "No match found for " + _ustr(self.expr)
 
-    def parseImpl( self, instring, loc, doActions=True ):
+    def parseImpl(self, instring, loc, doActions=True):
         startLoc = loc
         instrlen = len(instring)
         expr = self.expr
@@ -2874,28 +3035,29 @@ class SkipTo(ParseElementEnhance):
                 if self.ignoreExpr is not None:
                     while 1:
                         try:
-                            loc = self.ignoreExpr.tryParse(instring,loc)
+                            loc = self.ignoreExpr.tryParse(instring, loc)
                             # print("found ignoreExpr, advance to", loc)
                         except ParseBaseException:
                             break
-                expr._parse( instring, loc, doActions=False, callPreParse=False )
+                expr._parse(instring, loc, doActions=False, callPreParse=False)
                 skipText = instring[startLoc:loc]
                 if self.includeMatch:
-                    loc,mat = expr._parse(instring,loc,doActions,callPreParse=False)
+                    loc, mat = expr._parse(instring, loc, doActions, callPreParse=False)
                     if mat:
-                        skipRes = ParseResults( skipText )
+                        skipRes = ParseResults(skipText)
                         skipRes += mat
-                        return loc, [ skipRes ]
+                        return loc, [skipRes]
                     else:
-                        return loc, [ skipText ]
+                        return loc, [skipText]
                 else:
-                    return loc, [ skipText ]
-            except (ParseException,IndexError):
+                    return loc, [skipText]
+            except (ParseException, IndexError):
                 if failParse:
                     raise
                 else:
                     loc += 1
         raise ParseException(instring, loc, self.errmsg, self)
+
 
 class Forward(ParseElementEnhance):
     """Forward declaration of an expression to be defined later -
@@ -2912,46 +3074,47 @@ class Forward(ParseElementEnhance):
           fwdExpr << (a | b | c)
        Converting to use the '<<=' operator instead will avoid this problem.
     """
-    def __init__( self, other=None ):
-        super(Forward,self).__init__( other, savelist=False )
 
-    def __lshift__( self, other ):
-        if isinstance( other, basestring ):
+    def __init__(self, other=None):
+        super(Forward, self).__init__(other, savelist=False)
+
+    def __lshift__(self, other):
+        if isinstance(other, basestring):
             other = ParserElement.literalStringClass(other)
         self.expr = other
         self.mayReturnEmpty = other.mayReturnEmpty
         self.strRepr = None
         self.mayIndexError = self.expr.mayIndexError
         self.mayReturnEmpty = self.expr.mayReturnEmpty
-        self.setWhitespaceChars( self.expr.whiteChars )
+        self.setWhitespaceChars(self.expr.whiteChars)
         self.skipWhitespace = self.expr.skipWhitespace
         self.saveAsList = self.expr.saveAsList
         self.ignoreExprs.extend(self.expr.ignoreExprs)
         return self
-        
+
     def __ilshift__(self, other):
         return self << other
-    
-    def leaveWhitespace( self ):
+
+    def leaveWhitespace(self):
         self.skipWhitespace = False
         return self
 
-    def streamline( self ):
+    def streamline(self):
         if not self.streamlined:
             self.streamlined = True
             if self.expr is not None:
                 self.expr.streamline()
         return self
 
-    def validate( self, validateTrace=[] ):
+    def validate(self, validateTrace=[]):
         if self not in validateTrace:
-            tmp = validateTrace[:]+[self]
+            tmp = validateTrace[:] + [self]
             if self.expr is not None:
                 self.expr.validate(tmp)
         self.checkRecursion([])
 
-    def __str__( self ):
-        if hasattr(self,"name"):
+    def __str__(self):
+        if hasattr(self, "name"):
             return self.name
 
         self._revertClass = self.__class__
@@ -2967,31 +3130,36 @@ class Forward(ParseElementEnhance):
 
     def copy(self):
         if self.expr is not None:
-            return super(Forward,self).copy()
+            return super(Forward, self).copy()
         else:
             ret = Forward()
             ret <<= self
             return ret
 
+
 class _ForwardNoRecurse(Forward):
-    def __str__( self ):
+    def __str__(self):
         return "..."
+
 
 class TokenConverter(ParseElementEnhance):
     """Abstract subclass of C{ParseExpression}, for converting parsed results."""
-    def __init__( self, expr, savelist=False ):
-        super(TokenConverter,self).__init__( expr )#, savelist )
+
+    def __init__(self, expr, savelist=False):
+        super(TokenConverter, self).__init__(expr)  #, savelist )
         self.saveAsList = False
+
 
 class Upcase(TokenConverter):
     """Converter to upper case all matching tokens."""
-    def __init__(self, *args):
-        super(Upcase,self).__init__(*args)
-        warnings.warn("Upcase class is deprecated, use upcaseTokens parse action instead",
-                       DeprecationWarning,stacklevel=2)
 
-    def postParse( self, instring, loc, tokenlist ):
-        return list(map( str.upper, tokenlist ))
+    def __init__(self, *args):
+        super(Upcase, self).__init__(*args)
+        warnings.warn(
+            "Upcase class is deprecated, use upcaseTokens parse action instead", DeprecationWarning, stacklevel=2)
+
+    def postParse(self, instring, loc, tokenlist):
+        return list(map(str.upper, tokenlist))
 
 
 class Combine(TokenConverter):
@@ -2999,8 +3167,9 @@ class Combine(TokenConverter):
        By default, the matching patterns must also be contiguous in the input string;
        this can be disabled by specifying C{'adjacent=False'} in the constructor.
     """
-    def __init__( self, expr, joinString="", adjacent=True ):
-        super(Combine,self).__init__( expr )
+
+    def __init__(self, expr, joinString="", adjacent=True):
+        super(Combine, self).__init__(expr)
         # suppress whitespace-stripping in contained parse expressions, but re-enable it on the Combine itself
         if adjacent:
             self.leaveWhitespace()
@@ -3009,115 +3178,127 @@ class Combine(TokenConverter):
         self.joinString = joinString
         self.callPreparse = True
 
-    def ignore( self, other ):
+    def ignore(self, other):
         if self.adjacent:
             ParserElement.ignore(self, other)
         else:
-            super( Combine, self).ignore( other )
+            super(Combine, self).ignore(other)
         return self
 
-    def postParse( self, instring, loc, tokenlist ):
+    def postParse(self, instring, loc, tokenlist):
         retToks = tokenlist.copy()
         del retToks[:]
-        retToks += ParseResults([ "".join(tokenlist._asStringList(self.joinString)) ], modal=self.modalResults)
+        retToks += ParseResults(["".join(tokenlist._asStringList(self.joinString))], modal=self.modalResults)
 
         if self.resultsName and retToks.haskeys():
-            return [ retToks ]
+            return [retToks]
         else:
             return retToks
 
+
 class Group(TokenConverter):
     """Converter to return the matched tokens as a list - useful for returning tokens of C{L{ZeroOrMore}} and C{L{OneOrMore}} expressions."""
-    def __init__( self, expr ):
-        super(Group,self).__init__( expr )
+
+    def __init__(self, expr):
+        super(Group, self).__init__(expr)
         self.saveAsList = True
 
-    def postParse( self, instring, loc, tokenlist ):
-        return [ tokenlist ]
+    def postParse(self, instring, loc, tokenlist):
+        return [tokenlist]
+
 
 class Dict(TokenConverter):
     """Converter to return a repetitive expression as a list, but also as a dictionary.
        Each element can also be referenced using the first token in the expression as its key.
        Useful for tabular report scraping when the first column can be used as a item key.
     """
-    def __init__( self, expr ):
-        super(Dict,self).__init__( expr )
+
+    def __init__(self, expr):
+        super(Dict, self).__init__(expr)
         self.saveAsList = True
 
-    def postParse( self, instring, loc, tokenlist ):
-        for i,tok in enumerate(tokenlist):
+    def postParse(self, instring, loc, tokenlist):
+        for i, tok in enumerate(tokenlist):
             if len(tok) == 0:
                 continue
             ikey = tok[0]
-            if isinstance(ikey,int):
+            if isinstance(ikey, int):
                 ikey = _ustr(tok[0]).strip()
-            if len(tok)==1:
-                tokenlist[ikey] = _ParseResultsWithOffset("",i)
-            elif len(tok)==2 and not isinstance(tok[1],ParseResults):
-                tokenlist[ikey] = _ParseResultsWithOffset(tok[1],i)
+            if len(tok) == 1:
+                tokenlist[ikey] = _ParseResultsWithOffset("", i)
+            elif len(tok) == 2 and not isinstance(tok[1], ParseResults):
+                tokenlist[ikey] = _ParseResultsWithOffset(tok[1], i)
             else:
-                dictvalue = tok.copy() #ParseResults(i)
+                dictvalue = tok.copy()  #ParseResults(i)
                 del dictvalue[0]
-                if len(dictvalue)!= 1 or (isinstance(dictvalue,ParseResults) and dictvalue.haskeys()):
-                    tokenlist[ikey] = _ParseResultsWithOffset(dictvalue,i)
+                if len(dictvalue) != 1 or (isinstance(dictvalue, ParseResults) and dictvalue.haskeys()):
+                    tokenlist[ikey] = _ParseResultsWithOffset(dictvalue, i)
                 else:
-                    tokenlist[ikey] = _ParseResultsWithOffset(dictvalue[0],i)
+                    tokenlist[ikey] = _ParseResultsWithOffset(dictvalue[0], i)
 
         if self.resultsName:
-            return [ tokenlist ]
+            return [tokenlist]
         else:
             return tokenlist
 
 
 class Suppress(TokenConverter):
     """Converter for ignoring the results of a parsed expression."""
-    def postParse( self, instring, loc, tokenlist ):
+
+    def postParse(self, instring, loc, tokenlist):
         return []
 
-    def suppress( self ):
+    def suppress(self):
         return self
 
 
 class OnlyOnce(object):
     """Wrapper for parse actions, to ensure they are only called once."""
+
     def __init__(self, methodCall):
         self.callable = _trim_arity(methodCall)
         self.called = False
-    def __call__(self,s,l,t):
+
+    def __call__(self, s, l, t):
         if not self.called:
-            results = self.callable(s,l,t)
+            results = self.callable(s, l, t)
             self.called = True
             return results
-        raise ParseException(s,l,"")
+        raise ParseException(s, l, "")
+
     def reset(self):
         self.called = False
+
 
 def traceParseAction(f):
     """Decorator for debugging parse actions."""
     f = _trim_arity(f)
+
     def z(*paArgs):
         thisFunc = f.func_name
-        s,l,t = paArgs[-3:]
-        if len(paArgs)>3:
+        s, l, t = paArgs[-3:]
+        if len(paArgs) > 3:
             thisFunc = paArgs[0].__class__.__name__ + '.' + thisFunc
-        sys.stderr.write( ">>entering %s(line: '%s', %d, %s)\n" % (thisFunc,line(l,s),l,t) )
+        sys.stderr.write(">>entering %s(line: '%s', %d, %s)\n" % (thisFunc, line(l, s), l, t))
         try:
             ret = f(*paArgs)
         except Exception as exc:
-            sys.stderr.write( "<<leaving %s (exception: %s)\n" % (thisFunc,exc) )
+            sys.stderr.write("<<leaving %s (exception: %s)\n" % (thisFunc, exc))
             raise
-        sys.stderr.write( "<<leaving %s (ret: %s)\n" % (thisFunc,ret) )
+        sys.stderr.write("<<leaving %s (ret: %s)\n" % (thisFunc, ret))
         return ret
+
     try:
         z.__name__ = f.__name__
     except AttributeError:
         pass
     return z
 
+
 #
 # global helpers
 #
-def delimitedList( expr, delim=",", combine=False ):
+def delimitedList(expr, delim=",", combine=False):
     """Helper to define a delimited list of expressions - the delimiter defaults to ','.
        By default, the list elements and delimiters can have intervening whitespace, and
        comments, but this can be overridden by passing C{combine=True} in the constructor.
@@ -3125,13 +3306,14 @@ def delimitedList( expr, delim=",", combine=False ):
        string, with the delimiters included; otherwise, the matching tokens are returned
        as a list of tokens, with the delimiters suppressed.
     """
-    dlName = _ustr(expr)+" ["+_ustr(delim)+" "+_ustr(expr)+"]..."
+    dlName = _ustr(expr) + " [" + _ustr(delim) + " " + _ustr(expr) + "]..."
     if combine:
-        return Combine( expr + ZeroOrMore( delim + expr ) ).setName(dlName)
+        return Combine(expr + ZeroOrMore(delim + expr)).setName(dlName)
     else:
-        return ( expr + ZeroOrMore( Suppress( delim ) + expr ) ).setName(dlName)
+        return (expr + ZeroOrMore(Suppress(delim) + expr)).setName(dlName)
 
-def countedArray( expr, intExpr=None ):
+
+def countedArray(expr, intExpr=None):
     """Helper to define a counted list of expressions.
        This helper defines a pattern of the form::
            integer expr expr expr...
@@ -3139,26 +3321,30 @@ def countedArray( expr, intExpr=None ):
        The matched tokens returns the array of expr tokens as a list - the leading count token is suppressed.
     """
     arrayExpr = Forward()
-    def countFieldParseAction(s,l,t):
+
+    def countFieldParseAction(s, l, t):
         n = t[0]
-        arrayExpr << (n and Group(And([expr]*n)) or Group(empty))
+        arrayExpr << (n and Group(And([expr] * n)) or Group(empty))
         return []
+
     if intExpr is None:
-        intExpr = Word(nums).setParseAction(lambda t:int(t[0]))
+        intExpr = Word(nums).setParseAction(lambda t: int(t[0]))
     else:
         intExpr = intExpr.copy()
     intExpr.setName("arrayLen")
     intExpr.addParseAction(countFieldParseAction, callDuringTry=True)
-    return ( intExpr + arrayExpr )
+    return (intExpr + arrayExpr)
+
 
 def _flatten(L):
     ret = []
     for i in L:
-        if isinstance(i,list):
+        if isinstance(i, list):
             ret.extend(_flatten(i))
         else:
             ret.append(i)
     return ret
+
 
 def matchPreviousLiteral(expr):
     """Helper to define an expression that is indirectly defined from
@@ -3173,18 +3359,21 @@ def matchPreviousLiteral(expr):
        Do *not* use with packrat parsing enabled.
     """
     rep = Forward()
-    def copyTokenToRepeater(s,l,t):
+
+    def copyTokenToRepeater(s, l, t):
         if t:
             if len(t) == 1:
                 rep << t[0]
             else:
                 # flatten t tokens
                 tflat = _flatten(t.asList())
-                rep << And( [ Literal(tt) for tt in tflat ] )
+                rep << And([Literal(tt) for tt in tflat])
         else:
             rep << Empty()
+
     expr.addParseAction(copyTokenToRepeater, callDuringTry=True)
     return rep
+
 
 def matchPreviousExpr(expr):
     """Helper to define an expression that is indirectly defined from
@@ -3202,25 +3391,31 @@ def matchPreviousExpr(expr):
     rep = Forward()
     e2 = expr.copy()
     rep <<= e2
-    def copyTokenToRepeater(s,l,t):
+
+    def copyTokenToRepeater(s, l, t):
         matchTokens = _flatten(t.asList())
-        def mustMatchTheseTokens(s,l,t):
+
+        def mustMatchTheseTokens(s, l, t):
             theseTokens = _flatten(t.asList())
-            if  theseTokens != matchTokens:
-                raise ParseException("",0,"")
-        rep.setParseAction( mustMatchTheseTokens, callDuringTry=True )
+            if theseTokens != matchTokens:
+                raise ParseException("", 0, "")
+
+        rep.setParseAction(mustMatchTheseTokens, callDuringTry=True)
+
     expr.addParseAction(copyTokenToRepeater, callDuringTry=True)
     return rep
+
 
 def _escapeRegexRangeChars(s):
     #~  escape these chars: ^-]
     for c in r"\^-]":
-        s = s.replace(c,_bslash+c)
-    s = s.replace("\n",r"\n")
-    s = s.replace("\t",r"\t")
+        s = s.replace(c, _bslash + c)
+    s = s.replace("\n", r"\n")
+    s = s.replace("\t", r"\t")
     return _ustr(s)
 
-def oneOf( strs, caseless=False, useRegex=True ):
+
+def oneOf(strs, caseless=False, useRegex=True):
     """Helper to quickly define a set of alternative Literals, and makes sure to do
        longest-first testing when there is a conflict, regardless of the input order,
        but returns a C{L{MatchFirst}} for best performance.
@@ -3233,37 +3428,36 @@ def oneOf( strs, caseless=False, useRegex=True ):
           if creating a C{Regex} raises an exception)
     """
     if caseless:
-        isequal = ( lambda a,b: a.upper() == b.upper() )
-        masks = ( lambda a,b: b.upper().startswith(a.upper()) )
+        isequal = (lambda a, b: a.upper() == b.upper())
+        masks = (lambda a, b: b.upper().startswith(a.upper()))
         parseElementClass = CaselessLiteral
     else:
-        isequal = ( lambda a,b: a == b )
-        masks = ( lambda a,b: b.startswith(a) )
+        isequal = (lambda a, b: a == b)
+        masks = (lambda a, b: b.startswith(a))
         parseElementClass = Literal
 
     symbols = []
-    if isinstance(strs,basestring):
+    if isinstance(strs, basestring):
         symbols = strs.split()
     elif isinstance(strs, collections.Sequence):
         symbols = list(strs[:])
     elif isinstance(strs, _generatorType):
         symbols = list(strs)
     else:
-        warnings.warn("Invalid argument to oneOf, expected string or list",
-                SyntaxWarning, stacklevel=2)
+        warnings.warn("Invalid argument to oneOf, expected string or list", SyntaxWarning, stacklevel=2)
     if not symbols:
         return NoMatch()
 
     i = 0
-    while i < len(symbols)-1:
+    while i < len(symbols) - 1:
         cur = symbols[i]
-        for j,other in enumerate(symbols[i+1:]):
-            if ( isequal(other, cur) ):
-                del symbols[i+j+1]
+        for j, other in enumerate(symbols[i + 1:]):
+            if (isequal(other, cur)):
+                del symbols[i + j + 1]
                 break
-            elif ( masks(cur, other) ):
-                del symbols[i+j+1]
-                symbols.insert(i,other)
+            elif (masks(cur, other)):
+                del symbols[i + j + 1]
+                symbols.insert(i, other)
                 cur = other
                 break
         else:
@@ -3272,19 +3466,18 @@ def oneOf( strs, caseless=False, useRegex=True ):
     if not caseless and useRegex:
         #~ print (strs,"->", "|".join( [ _escapeRegexChars(sym) for sym in symbols] ))
         try:
-            if len(symbols)==len("".join(symbols)):
-                return Regex( "[%s]" % "".join(_escapeRegexRangeChars(sym) for sym in symbols) )
+            if len(symbols) == len("".join(symbols)):
+                return Regex("[%s]" % "".join(_escapeRegexRangeChars(sym) for sym in symbols))
             else:
-                return Regex( "|".join(re.escape(sym) for sym in symbols) )
+                return Regex("|".join(re.escape(sym) for sym in symbols))
         except:
-            warnings.warn("Exception creating Regex for oneOf, building MatchFirst",
-                    SyntaxWarning, stacklevel=2)
-
+            warnings.warn("Exception creating Regex for oneOf, building MatchFirst", SyntaxWarning, stacklevel=2)
 
     # last resort, just use MatchFirst
-    return MatchFirst( [ parseElementClass(sym) for sym in symbols ] )
+    return MatchFirst([parseElementClass(sym) for sym in symbols])
 
-def dictOf( key, value ):
+
+def dictOf(key, value):
     """Helper to easily and clearly define a dictionary by specifying the respective patterns
        for the key and value.  Takes care of defining the C{L{Dict}}, C{L{ZeroOrMore}}, and C{L{Group}} tokens
        in the proper order.  The key pattern can include delimiting markers or punctuation,
@@ -3292,7 +3485,8 @@ def dictOf( key, value ):
        pattern can include named results, so that the C{Dict} results can include named token
        fields.
     """
-    return Dict( ZeroOrMore( Group ( key + value ) ) )
+    return Dict(ZeroOrMore(Group(key + value)))
+
 
 def originalTextFor(expr, asString=True):
     """Helper to return the original, untokenized text for a given expression.  Useful to
@@ -3308,25 +3502,29 @@ def originalTextFor(expr, asString=True):
        the expression passed to C{L{originalTextFor}} contains expressions with defined
        results names, you must set C{asString} to C{False} if you want to preserve those
        results name values."""
-    locMarker = Empty().setParseAction(lambda s,loc,t: loc)
+    locMarker = Empty().setParseAction(lambda s, loc, t: loc)
     endlocMarker = locMarker.copy()
     endlocMarker.callPreparse = False
     matchExpr = locMarker("_original_start") + expr + endlocMarker("_original_end")
     if asString:
-        extractText = lambda s,l,t: s[t._original_start:t._original_end]
+        extractText = lambda s, l, t: s[t._original_start:t._original_end]
     else:
-        def extractText(s,l,t):
+
+        def extractText(s, l, t):
             del t[:]
             t.insert(0, s[t._original_start:t._original_end])
             del t["_original_start"]
             del t["_original_end"]
+
     matchExpr.setParseAction(extractText)
     return matchExpr
 
-def ungroup(expr): 
+
+def ungroup(expr):
     """Helper to undo pyparsing's default grouping of And expressions, even
        if all but one are non-empty."""
-    return TokenConverter(expr).setParseAction(lambda t:t[0])
+    return TokenConverter(expr).setParseAction(lambda t: t[0])
+
 
 def locatedExpr(expr):
     """Helper to decorate a returned token with its starting and ending locations in the input string.
@@ -3338,23 +3536,24 @@ def locatedExpr(expr):
        Be careful if the input text contains C{<TAB>} characters, you may want to call
        C{L{ParserElement.parseWithTabs}}
     """
-    locator = Empty().setParseAction(lambda s,l,t: l)
+    locator = Empty().setParseAction(lambda s, l, t: l)
     return Group(locator("locn_start") + expr("value") + locator.copy().leaveWhitespace()("locn_end"))
 
-
 # convenience constants for positional expressions
-empty       = Empty().setName("empty")
-lineStart   = LineStart().setName("lineStart")
-lineEnd     = LineEnd().setName("lineEnd")
+empty = Empty().setName("empty")
+lineStart = LineStart().setName("lineStart")
+lineEnd = LineEnd().setName("lineEnd")
 stringStart = StringStart().setName("stringStart")
-stringEnd   = StringEnd().setName("stringEnd")
+stringEnd = StringEnd().setName("stringEnd")
 
-_escapedPunc = Word( _bslash, r"\[]-*.$+^?()~ ", exact=2 ).setParseAction(lambda s,l,t:t[0][1])
-_escapedHexChar = Regex(r"\\0?[xX][0-9a-fA-F]+").setParseAction(lambda s,l,t:unichr(int(t[0].lstrip(r'\0x'),16)))
-_escapedOctChar = Regex(r"\\0[0-7]+").setParseAction(lambda s,l,t:unichr(int(t[0][1:],8)))
+_escapedPunc = Word(_bslash, r"\[]-*.$+^?()~ ", exact=2).setParseAction(lambda s, l, t: t[0][1])
+_escapedHexChar = Regex(r"\\0?[xX][0-9a-fA-F]+").setParseAction(lambda s, l, t: unichr(int(t[0].lstrip(r'\0x'), 16)))
+_escapedOctChar = Regex(r"\\0[0-7]+").setParseAction(lambda s, l, t: unichr(int(t[0][1:], 8)))
 _singleChar = _escapedPunc | _escapedHexChar | _escapedOctChar | Word(printables, excludeChars=r'\]', exact=1)
 _charRange = Group(_singleChar + Suppress("-") + _singleChar)
-_reBracketExpr = Literal("[") + Optional("^").setResultsName("negate") + Group( OneOrMore( _charRange | _singleChar ) ).setResultsName("body") + "]"
+_reBracketExpr = Literal("[") + Optional("^").setResultsName("negate") + Group(OneOrMore(
+    _charRange | _singleChar)).setResultsName("body") + "]"
+
 
 def srange(s):
     r"""Helper to easily define string ranges for use in Word construction.  Borrows
@@ -3379,39 +3578,49 @@ def srange(s):
     except:
         return ""
 
+
 def matchOnlyAtCol(n):
     """Helper method for defining parse actions that require matching at a specific
        column in the input text.
     """
-    def verifyCol(strg,locn,toks):
-        if col(locn,strg) != n:
-            raise ParseException(strg,locn,"matched token not at column %d" % n)
+
+    def verifyCol(strg, locn, toks):
+        if col(locn, strg) != n:
+            raise ParseException(strg, locn, "matched token not at column %d" % n)
+
     return verifyCol
+
 
 def replaceWith(replStr):
     """Helper method for common parse actions that simply return a literal value.  Especially
        useful when used with C{L{transformString<ParserElement.transformString>}()}.
     """
+
     def _replFunc(*args):
         return [replStr]
+
     return _replFunc
 
-def removeQuotes(s,l,t):
+
+def removeQuotes(s, l, t):
     """Helper parse action for removing quotation marks from parsed quoted strings.
        To use, add this parse action to quoted string using::
          quotedString.setParseAction( removeQuotes )
     """
     return t[0][1:-1]
 
-def upcaseTokens(s,l,t):
+
+def upcaseTokens(s, l, t):
     """Helper parse action to convert tokens to upper case."""
-    return [ tt.upper() for tt in map(_ustr,t) ]
+    return [tt.upper() for tt in map(_ustr, t)]
 
-def downcaseTokens(s,l,t):
+
+def downcaseTokens(s, l, t):
     """Helper parse action to convert tokens to lower case."""
-    return [ tt.lower() for tt in map(_ustr,t) ]
+    return [tt.lower() for tt in map(_ustr, t)]
 
-def keepOriginalText(s,startLoc,t):
+
+def keepOriginalText(s, startLoc, t):
     """DEPRECATED - use new helper method C{L{originalTextFor}}.
        Helper parse action to preserve original parsed text,
        overriding any nested parse actions."""
@@ -3422,6 +3631,7 @@ def keepOriginalText(s,startLoc,t):
     del t[:]
     t += ParseResults(s[startLoc:endloc])
     return t
+
 
 def getTokensEndLoc():
     """Method to be called from within a parse action to determine the end
@@ -3435,48 +3645,55 @@ def getTokensEndLoc():
                 endloc = f[0].f_locals["loc"]
                 return endloc
         else:
-            raise ParseFatalException("incorrect usage of getTokensEndLoc - may only be called from within a parse action")
+            raise ParseFatalException(
+                "incorrect usage of getTokensEndLoc - may only be called from within a parse action")
     finally:
         del fstack
 
+
 def _makeTags(tagStr, xml):
     """Internal helper to construct opening and closing tag expressions, given a tag name"""
-    if isinstance(tagStr,basestring):
+    if isinstance(tagStr, basestring):
         resname = tagStr
         tagStr = Keyword(tagStr, caseless=not xml)
     else:
         resname = tagStr.name
 
-    tagAttrName = Word(alphas,alphanums+"_-:")
+    tagAttrName = Word(alphas, alphanums + "_-:")
     if (xml):
-        tagAttrValue = dblQuotedString.copy().setParseAction( removeQuotes )
+        tagAttrValue = dblQuotedString.copy().setParseAction(removeQuotes)
         openTag = Suppress("<") + tagStr("tag") + \
                 Dict(ZeroOrMore(Group( tagAttrName + Suppress("=") + tagAttrValue ))) + \
                 Optional("/",default=[False]).setResultsName("empty").setParseAction(lambda s,l,t:t[0]=='/') + Suppress(">")
     else:
         printablesLessRAbrack = "".join(c for c in printables if c not in ">")
-        tagAttrValue = quotedString.copy().setParseAction( removeQuotes ) | Word(printablesLessRAbrack)
+        tagAttrValue = quotedString.copy().setParseAction(removeQuotes) | Word(printablesLessRAbrack)
         openTag = Suppress("<") + tagStr("tag") + \
                 Dict(ZeroOrMore(Group( tagAttrName.setParseAction(downcaseTokens) + \
                 Optional( Suppress("=") + tagAttrValue ) ))) + \
                 Optional("/",default=[False]).setResultsName("empty").setParseAction(lambda s,l,t:t[0]=='/') + Suppress(">")
     closeTag = Combine(_L("</") + tagStr + ">")
 
-    openTag = openTag.setResultsName("start"+"".join(resname.replace(":"," ").title().split())).setName("<%s>" % tagStr)
-    closeTag = closeTag.setResultsName("end"+"".join(resname.replace(":"," ").title().split())).setName("</%s>" % tagStr)
+    openTag = openTag.setResultsName("start" + "".join(resname.replace(":", " ").title().split())).setName("<%s>" %
+                                                                                                           tagStr)
+    closeTag = closeTag.setResultsName("end" + "".join(resname.replace(":", " ").title().split())).setName("</%s>" %
+                                                                                                           tagStr)
     openTag.tag = resname
     closeTag.tag = resname
     return openTag, closeTag
 
+
 def makeHTMLTags(tagStr):
     """Helper to construct opening and closing tag expressions for HTML, given a tag name"""
-    return _makeTags( tagStr, False )
+    return _makeTags(tagStr, False)
+
 
 def makeXMLTags(tagStr):
     """Helper to construct opening and closing tag expressions for XML, given a tag name"""
-    return _makeTags( tagStr, True )
+    return _makeTags(tagStr, True)
 
-def withAttribute(*args,**attrDict):
+
+def withAttribute(*args, **attrDict):
     """Helper to create a validating parse action to be used with start tags created
        with C{L{makeXMLTags}} or C{L{makeHTMLTags}}. Use C{withAttribute} to qualify a starting tag
        with a required attribute value, to avoid false matches on common tags such as
@@ -3498,22 +3715,27 @@ def withAttribute(*args,**attrDict):
         attrs = args[:]
     else:
         attrs = attrDict.items()
-    attrs = [(k,v) for k,v in attrs]
-    def pa(s,l,tokens):
-        for attrName,attrValue in attrs:
+    attrs = [(k, v) for k, v in attrs]
+
+    def pa(s, l, tokens):
+        for attrName, attrValue in attrs:
             if attrName not in tokens:
-                raise ParseException(s,l,"no matching attribute " + attrName)
+                raise ParseException(s, l, "no matching attribute " + attrName)
             if attrValue != withAttribute.ANY_VALUE and tokens[attrName] != attrValue:
-                raise ParseException(s,l,"attribute '%s' has value '%s', must be '%s'" %
-                                            (attrName, tokens[attrName], attrValue))
+                raise ParseException(s, l, "attribute '%s' has value '%s', must be '%s'" %
+                                     (attrName, tokens[attrName], attrValue))
+
     return pa
+
+
 withAttribute.ANY_VALUE = object()
 
 opAssoc = _Constants()
 opAssoc.LEFT = object()
 opAssoc.RIGHT = object()
 
-def infixNotation( baseExpr, opList, lpar=Suppress('('), rpar=Suppress(')') ):
+
+def infixNotation(baseExpr, opList, lpar=Suppress('('), rpar=Suppress(')')):
     """Helper method for constructing grammars of expressions made up of
        operators working in a precedence hierarchy.  Operators may be unary or
        binary, left- or right-associative.  Parse actions can also be attached
@@ -3540,22 +3762,23 @@ def infixNotation( baseExpr, opList, lpar=Suppress('('), rpar=Suppress(')') ):
         - rpar - expression for matching right-parentheses (default=Suppress(')'))
     """
     ret = Forward()
-    lastExpr = baseExpr | ( lpar + ret + rpar )
-    for i,operDef in enumerate(opList):
-        opExpr,arity,rightLeftAssoc,pa = (operDef + (None,))[:4]
+    lastExpr = baseExpr | (lpar + ret + rpar)
+    for i, operDef in enumerate(opList):
+        opExpr, arity, rightLeftAssoc, pa = (operDef + (None, ))[:4]
         if arity == 3:
             if opExpr is None or len(opExpr) != 2:
                 raise ValueError("if numterms=3, opExpr must be a tuple or list of two expressions")
             opExpr1, opExpr2 = opExpr
-        thisExpr = Forward()#.setName("expr%d" % i)
+        thisExpr = Forward()  #.setName("expr%d" % i)
         if rightLeftAssoc == opAssoc.LEFT:
             if arity == 1:
-                matchExpr = FollowedBy(lastExpr + opExpr) + Group( lastExpr + OneOrMore( opExpr ) )
+                matchExpr = FollowedBy(lastExpr + opExpr) + Group(lastExpr + OneOrMore(opExpr))
             elif arity == 2:
                 if opExpr is not None:
-                    matchExpr = FollowedBy(lastExpr + opExpr + lastExpr) + Group( lastExpr + OneOrMore( opExpr + lastExpr ) )
+                    matchExpr = FollowedBy(lastExpr + opExpr + lastExpr) + Group(lastExpr + OneOrMore(opExpr +
+                                                                                                      lastExpr))
                 else:
-                    matchExpr = FollowedBy(lastExpr+lastExpr) + Group( lastExpr + OneOrMore(lastExpr) )
+                    matchExpr = FollowedBy(lastExpr + lastExpr) + Group(lastExpr + OneOrMore(lastExpr))
             elif arity == 3:
                 matchExpr = FollowedBy(lastExpr + opExpr1 + lastExpr + opExpr2 + lastExpr) + \
                             Group( lastExpr + opExpr1 + lastExpr + opExpr2 + lastExpr )
@@ -3566,12 +3789,13 @@ def infixNotation( baseExpr, opList, lpar=Suppress('('), rpar=Suppress(')') ):
                 # try to avoid LR with this extra test
                 if not isinstance(opExpr, Optional):
                     opExpr = Optional(opExpr)
-                matchExpr = FollowedBy(opExpr.expr + thisExpr) + Group( opExpr + thisExpr )
+                matchExpr = FollowedBy(opExpr.expr + thisExpr) + Group(opExpr + thisExpr)
             elif arity == 2:
                 if opExpr is not None:
-                    matchExpr = FollowedBy(lastExpr + opExpr + thisExpr) + Group( lastExpr + OneOrMore( opExpr + thisExpr ) )
+                    matchExpr = FollowedBy(lastExpr + opExpr + thisExpr) + Group(lastExpr + OneOrMore(opExpr +
+                                                                                                      thisExpr))
                 else:
-                    matchExpr = FollowedBy(lastExpr + thisExpr) + Group( lastExpr + OneOrMore( thisExpr ) )
+                    matchExpr = FollowedBy(lastExpr + thisExpr) + Group(lastExpr + OneOrMore(thisExpr))
             elif arity == 3:
                 matchExpr = FollowedBy(lastExpr + opExpr1 + thisExpr + opExpr2 + thisExpr) + \
                             Group( lastExpr + opExpr1 + thisExpr + opExpr2 + thisExpr )
@@ -3580,17 +3804,24 @@ def infixNotation( baseExpr, opList, lpar=Suppress('('), rpar=Suppress(')') ):
         else:
             raise ValueError("operator must indicate right or left associativity")
         if pa:
-            matchExpr.setParseAction( pa )
-        thisExpr <<= ( matchExpr | lastExpr )
+            matchExpr.setParseAction(pa)
+        thisExpr <<= (matchExpr | lastExpr)
         lastExpr = thisExpr
     ret <<= lastExpr
     return ret
+
+
 operatorPrecedence = infixNotation
 
-dblQuotedString = Regex(r'"(?:[^"\n\r\\]|(?:"")|(?:\\x[0-9a-fA-F]+)|(?:\\.))*"').setName("string enclosed in double quotes")
-sglQuotedString = Regex(r"'(?:[^'\n\r\\]|(?:'')|(?:\\x[0-9a-fA-F]+)|(?:\\.))*'").setName("string enclosed in single quotes")
-quotedString = Regex(r'''(?:"(?:[^"\n\r\\]|(?:"")|(?:\\x[0-9a-fA-F]+)|(?:\\.))*")|(?:'(?:[^'\n\r\\]|(?:'')|(?:\\x[0-9a-fA-F]+)|(?:\\.))*')''').setName("quotedString using single or double quotes")
+dblQuotedString = Regex(r'"(?:[^"\n\r\\]|(?:"")|(?:\\x[0-9a-fA-F]+)|(?:\\.))*"').setName(
+    "string enclosed in double quotes")
+sglQuotedString = Regex(r"'(?:[^'\n\r\\]|(?:'')|(?:\\x[0-9a-fA-F]+)|(?:\\.))*'").setName(
+    "string enclosed in single quotes")
+quotedString = Regex(
+    r'''(?:"(?:[^"\n\r\\]|(?:"")|(?:\\x[0-9a-fA-F]+)|(?:\\.))*")|(?:'(?:[^'\n\r\\]|(?:'')|(?:\\x[0-9a-fA-F]+)|(?:\\.))*')''').setName(
+        "quotedString using single or double quotes")
 unicodeString = Combine(_L('u') + quotedString.copy())
+
 
 def nestedExpr(opener="(", closer=")", content=None, ignoreExpr=quotedString.copy()):
     """Helper method for defining nested lists enclosed in opening and closing
@@ -3616,33 +3847,34 @@ def nestedExpr(opener="(", closer=")", content=None, ignoreExpr=quotedString.cop
     if opener == closer:
         raise ValueError("opening and closing strings cannot be the same")
     if content is None:
-        if isinstance(opener,basestring) and isinstance(closer,basestring):
-            if len(opener) == 1 and len(closer)==1:
+        if isinstance(opener, basestring) and isinstance(closer, basestring):
+            if len(opener) == 1 and len(closer) == 1:
                 if ignoreExpr is not None:
-                    content = (Combine(OneOrMore(~ignoreExpr +
-                                    CharsNotIn(opener+closer+ParserElement.DEFAULT_WHITE_CHARS,exact=1))
-                                ).setParseAction(lambda t:t[0].strip()))
+                    content = (Combine(
+                        OneOrMore(~ignoreExpr + CharsNotIn(
+                            opener + closer + ParserElement.DEFAULT_WHITE_CHARS, exact=1))).setParseAction(
+                                lambda t: t[0].strip()))
                 else:
-                    content = (empty.copy()+CharsNotIn(opener+closer+ParserElement.DEFAULT_WHITE_CHARS
-                                ).setParseAction(lambda t:t[0].strip()))
+                    content = (empty.copy() + CharsNotIn(
+                        opener + closer + ParserElement.DEFAULT_WHITE_CHARS).setParseAction(lambda t: t[0].strip()))
             else:
                 if ignoreExpr is not None:
-                    content = (Combine(OneOrMore(~ignoreExpr + 
-                                    ~Literal(opener) + ~Literal(closer) +
-                                    CharsNotIn(ParserElement.DEFAULT_WHITE_CHARS,exact=1))
-                                ).setParseAction(lambda t:t[0].strip()))
+                    content = (Combine(
+                        OneOrMore(~ignoreExpr + ~Literal(opener) + ~Literal(closer) + CharsNotIn(
+                            ParserElement.DEFAULT_WHITE_CHARS, exact=1))).setParseAction(lambda t: t[0].strip()))
                 else:
-                    content = (Combine(OneOrMore(~Literal(opener) + ~Literal(closer) +
-                                    CharsNotIn(ParserElement.DEFAULT_WHITE_CHARS,exact=1))
-                                ).setParseAction(lambda t:t[0].strip()))
+                    content = (Combine(
+                        OneOrMore(~Literal(opener) + ~Literal(closer) + CharsNotIn(
+                            ParserElement.DEFAULT_WHITE_CHARS, exact=1))).setParseAction(lambda t: t[0].strip()))
         else:
             raise ValueError("opening and closing arguments must be strings if no content expression is given")
     ret = Forward()
     if ignoreExpr is not None:
-        ret <<= Group( Suppress(opener) + ZeroOrMore( ignoreExpr | ret | content ) + Suppress(closer) )
+        ret <<= Group(Suppress(opener) + ZeroOrMore(ignoreExpr | ret | content) + Suppress(closer))
     else:
-        ret <<= Group( Suppress(opener) + ZeroOrMore( ret | content )  + Suppress(closer) )
+        ret <<= Group(Suppress(opener) + ZeroOrMore(ret | content) + Suppress(closer))
     return ret
+
 
 def indentedBlock(blockStatementExpr, indentStack, indent=True):
     """Helper method for defining space-delimited indentation blocks, such as
@@ -3660,49 +3892,51 @@ def indentedBlock(blockStatementExpr, indentStack, indent=True):
 
        A valid block must contain at least one C{blockStatement}.
     """
-    def checkPeerIndent(s,l,t):
+
+    def checkPeerIndent(s, l, t):
         if l >= len(s): return
-        curCol = col(l,s)
+        curCol = col(l, s)
         if curCol != indentStack[-1]:
             if curCol > indentStack[-1]:
-                raise ParseFatalException(s,l,"illegal nesting")
-            raise ParseException(s,l,"not a peer entry")
+                raise ParseFatalException(s, l, "illegal nesting")
+            raise ParseException(s, l, "not a peer entry")
 
-    def checkSubIndent(s,l,t):
-        curCol = col(l,s)
+    def checkSubIndent(s, l, t):
+        curCol = col(l, s)
         if curCol > indentStack[-1]:
-            indentStack.append( curCol )
+            indentStack.append(curCol)
         else:
-            raise ParseException(s,l,"not a subentry")
+            raise ParseException(s, l, "not a subentry")
 
-    def checkUnindent(s,l,t):
+    def checkUnindent(s, l, t):
         if l >= len(s): return
-        curCol = col(l,s)
-        if not(indentStack and curCol < indentStack[-1] and curCol <= indentStack[-2]):
-            raise ParseException(s,l,"not an unindent")
+        curCol = col(l, s)
+        if not (indentStack and curCol < indentStack[-1] and curCol <= indentStack[-2]):
+            raise ParseException(s, l, "not an unindent")
         indentStack.pop()
 
     NL = OneOrMore(LineEnd().setWhitespaceChars("\t ").suppress())
     INDENT = Empty() + Empty().setParseAction(checkSubIndent)
-    PEER   = Empty().setParseAction(checkPeerIndent)
+    PEER = Empty().setParseAction(checkPeerIndent)
     UNDENT = Empty().setParseAction(checkUnindent)
     if indent:
-        smExpr = Group( Optional(NL) +
+        smExpr = Group(
+            Optional(NL) +
             #~ FollowedBy(blockStatementExpr) +
-            INDENT + (OneOrMore( PEER + Group(blockStatementExpr) + Optional(NL) )) + UNDENT)
+            INDENT + (OneOrMore(PEER + Group(blockStatementExpr) + Optional(NL))) + UNDENT)
     else:
-        smExpr = Group( Optional(NL) +
-            (OneOrMore( PEER + Group(blockStatementExpr) + Optional(NL) )) )
+        smExpr = Group(Optional(NL) + (OneOrMore(PEER + Group(blockStatementExpr) + Optional(NL))))
     blockStatementExpr.ignore(_bslash + LineEnd())
     return smExpr
+
 
 alphas8bit = srange(r"[\0xc0-\0xd6\0xd8-\0xf6\0xf8-\0xff]")
 punc8bit = srange(r"[\0xa1-\0xbf\0xd7\0xf7]")
 
-anyOpenTag,anyCloseTag = makeHTMLTags(Word(alphas,alphanums+"_:"))
-commonHTMLEntity = Combine(_L("&") + oneOf("gt lt amp nbsp quot").setResultsName("entity") +";").streamline()
-_htmlEntityMap = dict(zip("gt lt amp nbsp quot".split(),'><& "'))
-replaceHTMLEntity = lambda t : t.entity in _htmlEntityMap and _htmlEntityMap[t.entity] or None
+anyOpenTag, anyCloseTag = makeHTMLTags(Word(alphas, alphanums + "_:"))
+commonHTMLEntity = Combine(_L("&") + oneOf("gt lt amp nbsp quot").setResultsName("entity") + ";").streamline()
+_htmlEntityMap = dict(zip("gt lt amp nbsp quot".split(), '><& "'))
+replaceHTMLEntity = lambda t: t.entity in _htmlEntityMap and _htmlEntityMap[t.entity] or None
 
 # it's easy to get these comment structures wrong - they're very common, so may as well make them available
 cStyleComment = Regex(r"/\*(?:[^*]*\*+)+?/").setName("C style comment")
@@ -3714,51 +3948,52 @@ cppStyleComment = Regex(r"/(?:\*(?:[^*]*\*+)+?/|/[^\n]*(?:\n[^\n]*)*?(?:(?<!\\)|
 
 javaStyleComment = cppStyleComment
 pythonStyleComment = Regex(r"#.*").setName("Python style comment")
-_commasepitem = Combine(OneOrMore(Word(printables, excludeChars=',') +
-                                  Optional( Word(" \t") +
-                                            ~Literal(",") + ~LineEnd() ) ) ).streamline().setName("commaItem")
-commaSeparatedList = delimitedList( Optional( quotedString.copy() | _commasepitem, default="") ).setName("commaSeparatedList")
-
+_commasepitem = Combine(
+    OneOrMore(Word(
+        printables, excludeChars=',') + Optional(Word(" \t") + ~Literal(",") + ~LineEnd()))).streamline().setName(
+            "commaItem")
+commaSeparatedList = delimitedList(Optional(
+    quotedString.copy() | _commasepitem, default="")).setName("commaSeparatedList")
 
 if __name__ == "__main__":
 
-    def test( teststring ):
+    def test(teststring):
         try:
-            tokens = simpleSQL.parseString( teststring )
+            tokens = simpleSQL.parseString(teststring)
             tokenlist = tokens.asList()
-            print (teststring + "->"   + str(tokenlist))
-            print ("tokens = "         + str(tokens))
-            print ("tokens.columns = " + str(tokens.columns))
-            print ("tokens.tables = "  + str(tokens.tables))
-            print (tokens.asXML("SQL",True))
+            print(teststring + "->" + str(tokenlist))
+            print("tokens = " + str(tokens))
+            print("tokens.columns = " + str(tokens.columns))
+            print("tokens.tables = " + str(tokens.tables))
+            print(tokens.asXML("SQL", True))
         except ParseBaseException as err:
-            print (teststring + "->")
-            print (err.line)
-            print (" "*(err.column-1) + "^")
-            print (err)
+            print(teststring + "->")
+            print(err.line)
+            print(" " * (err.column - 1) + "^")
+            print(err)
         print()
 
-    selectToken    = CaselessLiteral( "select" )
-    fromToken      = CaselessLiteral( "from" )
+    selectToken = CaselessLiteral("select")
+    fromToken = CaselessLiteral("from")
 
-    ident          = Word( alphas, alphanums + "_$" )
-    columnName     = delimitedList( ident, ".", combine=True ).setParseAction( upcaseTokens )
-    columnNameList = Group( delimitedList( columnName ) )#.setName("columns")
-    tableName      = delimitedList( ident, ".", combine=True ).setParseAction( upcaseTokens )
-    tableNameList  = Group( delimitedList( tableName ) )#.setName("tables")
+    ident = Word(alphas, alphanums + "_$")
+    columnName = delimitedList(ident, ".", combine=True).setParseAction(upcaseTokens)
+    columnNameList = Group(delimitedList(columnName))  #.setName("columns")
+    tableName = delimitedList(ident, ".", combine=True).setParseAction(upcaseTokens)
+    tableNameList = Group(delimitedList(tableName))  #.setName("tables")
     simpleSQL      = ( selectToken + \
                      ( '*' | columnNameList ).setResultsName( "columns" ) + \
                      fromToken + \
                      tableNameList.setResultsName( "tables" ) )
 
-    test( "SELECT * from XYZZY, ABC" )
-    test( "select * from SYS.XYZZY" )
-    test( "Select A from Sys.dual" )
-    test( "Select AA,BB,CC from Sys.dual" )
-    test( "Select A, B, C from Sys.dual" )
-    test( "Select A, B, C from Sys.dual" )
-    test( "Xelect A, B, C from Sys.dual" )
-    test( "Select A, B, C frox Sys.dual" )
-    test( "Select" )
-    test( "Select ^^^ frox Sys.dual" )
-    test( "Select A, B, C from Sys.dual, Table2   " )
+    test("SELECT * from XYZZY, ABC")
+    test("select * from SYS.XYZZY")
+    test("Select A from Sys.dual")
+    test("Select AA,BB,CC from Sys.dual")
+    test("Select A, B, C from Sys.dual")
+    test("Select A, B, C from Sys.dual")
+    test("Xelect A, B, C from Sys.dual")
+    test("Select A, B, C frox Sys.dual")
+    test("Select")
+    test("Select ^^^ frox Sys.dual")
+    test("Select A, B, C from Sys.dual, Table2   ")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
C++ and Python sources are now formatted according to the `.clang-format` and `.style.yapf` style files.

We should get more meaningful diffs from now on, if everyone adheres to the code style. There are a couple of things you can do to make sure of this:
1. Install the Git hooks on your local clone. This is explained in the documentation.
2. Integrate the code style checkers with you editor, to reformat the code when saving and/or exiting.
3. Run `clang-format` and/or `yapf` by hand before committing.

@MinazoBot will make anyway check that the code formatting is compliant to the style.

## Todos
<!--- Notable points that this PR has either accomplished or will accomplish. -->
* **Developer Interest**
<!--- Changes affecting developers -->
  - [x] Formatting of code

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go


