### PR TITLE
Removed error in "code-block" directive

### DIFF
--- a/doc/programmers/maintenance.rst
+++ b/doc/programmers/maintenance.rst
@@ -102,6 +102,7 @@ The Python script checks the ``.gitattributes`` file to determine which license
 headers need to be maintained and in which files:
 
 .. code-block:: bash
+
    src/pedra/pedra_dlapack.F90 !licensefile
    src/solver/*.hpp licensefile=.githooks/LICENSE-C++
 


### PR DESCRIPTION
line break was missing. The following error was produced during `make doc`:
```
folder/doc/programmers/maintenance.rst:104: ERROR: Error in "code-block" directive:
maximum 1 argument(s) allowed, 5 supplied.

.. code-block:: bash
   src/pedra/pedra_dlapack.F90 !licensefile
   src/solver/*.hpp licensefile=.githooks/LICENSE-C++
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go


