### PR TITLE
Update default.nix and .envrc

### DIFF
--- a/.ci/Dangerfile
+++ b/.ci/Dangerfile
@@ -97,4 +97,4 @@ if has_deleted_files && !has_gitattributes_changes
   warn("You have removed source files without updating `.gitattributes`.", :sticky => false)
 end
 
-lgtm.check_lgtm
+lgtm.check_lgtm image_url: 'https://media.giphy.com/media/tIeCLkB8geYtW/giphy.gif'

--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,7 @@
-use nix
+use nix default.nix --indirect --add-root $HOME/.nix-gc-root/pcmsolver-shell.drv
+export SOURCE_DATE_EPOCH=$(date +%s)
+dir_hash=pcmsolver-$(echo -n pcmsolver | shasum | cut -d ' ' -f 1)
+direnv_layout_dir=$XDG_CACHE_HOME/direnv/layouts/$dir_hash
+layout python
+pip install -r requirements.txt --upgrade
 export NINJA_STATUS="[Built edge %f of %t in %e sec]"

--- a/.envrc
+++ b/.envrc
@@ -2,6 +2,6 @@ use nix default.nix --indirect --add-root $HOME/.nix-gc-root/pcmsolver-shell.drv
 export SOURCE_DATE_EPOCH=$(date +%s)
 dir_hash=pcmsolver-$(echo -n pcmsolver | shasum | cut -d ' ' -f 1)
 direnv_layout_dir=$XDG_CACHE_HOME/direnv/layouts/$dir_hash
-layout python
-pip install -r requirements.txt --upgrade pip
+layout python `type -P python` --system-site-packages
+pip install -r requirements.txt
 export NINJA_STATUS="[Built edge %f of %t in %e sec]"

--- a/.envrc
+++ b/.envrc
@@ -3,5 +3,5 @@ export SOURCE_DATE_EPOCH=$(date +%s)
 dir_hash=pcmsolver-$(echo -n pcmsolver | shasum | cut -d ' ' -f 1)
 direnv_layout_dir=$XDG_CACHE_HOME/direnv/layouts/$dir_hash
 layout python
-pip install -r requirements.txt --upgrade
+pip install -r requirements.txt --upgrade pip
 export NINJA_STATUS="[Built edge %f of %t in %e sec]"

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 # Python stuff
 *.pyc
 .venv
+.direnv
 
 # Autocmake stuff
 cmake/lib/*.pyc

--- a/default.nix
+++ b/default.nix
@@ -20,12 +20,13 @@ in
       cmake
       doxygen
       exa
-      gcc
+      #gcc
       gdb
       gfortran
       graphviz
       lldb
-      openmpi
+      python35Packages.matplotlib
+      python35Packages.numpy
       python35Packages.virtualenvwrapper
       valgrind
       zlib

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,15 @@
-with import <nixpkgs> {}; {
-  pcmEnv = stdenv.mkDerivation {
-    name = "PCMSolver";
+let
+  hostPkgs = import <nixpkgs> {};
+  nixpkgs = (hostPkgs.fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs-channels";
+    rev = "ac355040656de04f59406ba2380a96f4124ebdad";
+    sha256 = "0frhc7mnx88sird6ipp6578k5badibsl0jfa22ab9w6qrb88j825";
+  });
+in
+  with import nixpkgs {};
+  stdenv.mkDerivation {
+    name = "PCMSolver-dev";
     buildInputs = [
       boost
       bundler
@@ -10,23 +19,15 @@ with import <nixpkgs> {}; {
       clang-tools
       cmake
       doxygen
+      exa
       gcc
       gdb
       gfortran
+      graphviz
       lldb
       openmpi
-      python35Packages.breathe
-      python35Packages.jupyter
-      python35Packages.matplotlib
-      python35Packages.numpy
-      python35Packages.pyyaml
-      python35Packages.recommonmark
-      python35Packages.scipy
-      python35Packages.sphinx
-      python35Packages.sphinx_rtd_theme
-      python35Packages.sympy
+      python35Packages.virtualenvwrapper
       valgrind
       zlib
     ];
-  };
-}
+  }

--- a/src/bi_operators/BIOperatorData.hpp
+++ b/src/bi_operators/BIOperatorData.hpp
@@ -25,11 +25,12 @@
 
 #include "Config.hpp"
 
-/*! @struct BIOperatorData
- *  @brief Contains all data defined from user input to set up the bi_operatorss
- */
+/*! \file BIOperatorData.hpp */
 
 namespace pcm {
+/*! \struct BIOperatorData
+ *  \brief Contains all data defined from user input to set up the bi_operators
+ */
 struct BIOperatorData {
   /*! Scaling for the diagonal of the approximate collocation matrices */
   double scaling;

--- a/src/bi_operators/Collocation.hpp
+++ b/src/bi_operators/Collocation.hpp
@@ -68,8 +68,16 @@ private:
    * the S and D operators
    */
   double factor_;
+  /*! Computes the matrix representation of the single layer operator
+   *  \param[in] elems list of finite elements of the discretized cavity
+   *  \param[in] gf  a Green's function
+   */
   virtual Eigen::MatrixXd computeS_impl(const std::vector<cavity::Element> & elems,
                                         const IGreensFunction & gf) const __override;
+  /*! Computes the matrix representation of the double layer operator
+   *  \param[in] elems list of finite elements of the discretized cavity
+   *  \param[in] gf  a Green's function
+   */
   virtual Eigen::MatrixXd computeD_impl(const std::vector<cavity::Element> & elems,
                                         const IGreensFunction & gf) const __override;
 };

--- a/src/bi_operators/IBoundaryIntegralOperator.hpp
+++ b/src/bi_operators/IBoundaryIntegralOperator.hpp
@@ -41,12 +41,28 @@ namespace pcm {
 class IBoundaryIntegralOperator {
 public:
   virtual ~IBoundaryIntegralOperator() {}
+  /*! Computes the matrix representation of the single layer operator
+   *  \param[in] cav the discretized cavity
+   *  \param[in] gf  a Green's function
+   */
   Eigen::MatrixXd computeS(const ICavity & cav, const IGreensFunction & gf) const;
+  /*! Computes the matrix representation of the double layer operator
+   *  \param[in] cav the discretized cavity
+   *  \param[in] gf  a Green's function
+   */
   Eigen::MatrixXd computeD(const ICavity & cav, const IGreensFunction & gf) const;
 
 private:
+  /*! Computes the matrix representation of the single layer operator
+   *  \param[in] elems list of finite elements of the discretized cavity
+   *  \param[in] gf  a Green's function
+   */
   virtual Eigen::MatrixXd computeS_impl(const std::vector<cavity::Element> & elems,
                                         const IGreensFunction & gf) const = 0;
+  /*! Computes the matrix representation of the double layer operator
+   *  \param[in] elems list of finite elements of the discretized cavity
+   *  \param[in] gf  a Green's function
+   */
   virtual Eigen::MatrixXd computeD_impl(const std::vector<cavity::Element> & elems,
                                         const IGreensFunction & gf) const = 0;
 };

--- a/src/bi_operators/Numerical.hpp
+++ b/src/bi_operators/Numerical.hpp
@@ -29,6 +29,8 @@
 
 #include <Eigen/Core>
 
+/*! \file Numerical.hpp */
+
 namespace pcm {
 struct BIOperatorData;
 namespace cavity {
@@ -41,8 +43,7 @@ class IGreensFunction;
 
 namespace pcm {
 namespace bi_operators {
-/*! \file Numerical.hpp
- *  \class Numerical
+/*! \class Numerical
  *  \brief Implementation of the single and double layer operators matrix
  *representation using one-point collocation
  *  \author Roberto Di Remigio
@@ -53,8 +54,16 @@ namespace bi_operators {
  */
 class Numerical __final : public IBoundaryIntegralOperator {
 private:
+  /*! Computes the matrix representation of the single layer operator
+   *  \param[in] elems list of finite elements of the discretized cavity
+   *  \param[in] gf  a Green's function
+   */
   virtual Eigen::MatrixXd computeS_impl(const std::vector<cavity::Element> & elems,
                                         const IGreensFunction & gf) const __override;
+  /*! Computes the matrix representation of the double layer operator
+   *  \param[in] elems list of finite elements of the discretized cavity
+   *  \param[in] gf  a Green's function
+   */
   virtual Eigen::MatrixXd computeD_impl(const std::vector<cavity::Element> & elems,
                                         const IGreensFunction & gf) const __override;
 };
@@ -75,8 +84,11 @@ typedef pcm::function<double(const Eigen::Vector3d &,
                              const Eigen::Vector3d &)>
     KernelD;
 
-/*! \brief Integrates a single layer type operator on a single spherical polygon
+/*! \fn double integrateS(const KernelS & F, const cavity::Element & e)
+ *  \brief Integrates a single layer type operator on a single spherical polygon
  *  \date 2014
+ *  \param[in] F single layer type operator
+ *  \param[in] e a finite element on the cavity
  *  \tparam PhiPoints Gaussian rule to be used in the angular phi integration
  *  \tparam ThetaPoints Gaussian rule to be used in the angular theta integration
  *
@@ -86,8 +98,11 @@ typedef pcm::function<double(const Eigen::Vector3d &,
 template <int PhiPoints, int ThetaPoints>
 double integrateS(const KernelS & F, const cavity::Element & e);
 
-/*! \brief Integrates a double layer type operator on a single spherical polygon
+/*! \fn double integrateD(const KernelD & F, const cavity::Element & e)
+ *  \brief Integrates a double layer type operator on a single spherical polygon
  *  \date 2014
+ *  \param[in] F double layer type operator
+ *  \param[in] e a finite element on the cavity
  *  \tparam PhiPoints Gaussian rule to be used in the angular phi integration
  *  \tparam ThetaPoints Gaussian rule to be used in the angular theta integration
  *

--- a/src/bi_operators/Purisima.hpp
+++ b/src/bi_operators/Purisima.hpp
@@ -65,11 +65,15 @@ private:
    * the S operator
    */
   double factor_;
+  /*! Computes the matrix representation of the single layer operator
+   *  \param[in] elems list of finite elements of the discretized cavity
+   *  \param[in] gf  a Green's function
+   */
   virtual Eigen::MatrixXd computeS_impl(const std::vector<cavity::Element> & elems,
                                         const IGreensFunction & gf) const __override;
   /*! Computes the matrix representation of the double layer operator by collocation
    *  using the Purisima sum rule to compute the diagonal elements.
-   *  \param[in] cav discretized cavity
+   *  \param[in] elems discretized cavity
    *  \param[in] gf  a Green's function
    *
    *  The sum rule for the diagonal elements is:

--- a/src/cavity/Element.hpp
+++ b/src/cavity/Element.hpp
@@ -30,8 +30,12 @@
 
 #include "utils/Sphere.hpp"
 
-/*! \file Element.hpp
- *  \class Element
+/*! \file Element.hpp */
+
+namespace pcm {
+using utils::Sphere;
+namespace cavity {
+/*! \class Element
  *  \brief Element data structure
  *  \author Roberto Di Remigio
  *  \date 2014
@@ -39,10 +43,6 @@
  *  Data structure containing relevant information about a finite element
  *  making up the cavity
  */
-
-namespace pcm {
-using utils::Sphere;
-namespace cavity {
 class Element __final {
 public:
   Element(int nv,
@@ -126,12 +126,12 @@ private:
   }
 };
 
+namespace detail {
 /*! \brief Calculate tangent and bitangent vector for the representative point
  *  \param[in]  n_ normal vector
  *  \param[out] t_ tangent vector
  *  \param[out] b_ bitangent vector
  */
-namespace detail {
 void tangent_and_bitangent(const Eigen::Vector3d & n_,
                            Eigen::Vector3d & t_,
                            Eigen::Vector3d & b_);

--- a/src/green/dielectric_profile/OneLayerErf.hpp
+++ b/src/green/dielectric_profile/OneLayerErf.hpp
@@ -30,17 +30,17 @@
 
 #include <boost/math/special_functions/erf.hpp>
 
-/*! \file OneLayerErf.hpp
- *  \class OneLayerErf
+/*! \file OneLayerErf.hpp */
+
+namespace pcm {
+namespace dielectric_profile {
+/*!  \class OneLayerErf
  *  \brief A erf dielectric profile
  *  \author Roberto Di Remigio
  *  \date 2015
  *  \note The parameter given from user input for width_ is divided by 6.0 in
  *  the constructor to keep consistency with \cite Frediani2004a
  */
-
-namespace pcm {
-namespace dielectric_profile {
 class OneLayerErf {
 private:
   /// Dielectric constant on the left of the interface


### PR DESCRIPTION
## Description
This is mainly for my own use and those brave enough to use the [Nix package manager](https://nixos.org/nix/)
The `default.nix` now pins down dependencies to a certain version of the `nixpkgs`. The `nix-shell` should be generated so that it persists even when running garbage collection:
```
use nix default.nix --indirect --add-root $HOME/.nix-gc-root/pcmsolver-shell.drv
```
`.envrc` does just that now.
The `default.nix` now only install the `virtualenv` Python package. `direnv` will then activate it and install dependencies listed in `requirements.txt`.
**IMPORTANT**
I have moved `requirements.txt` from `doc` to the project root. This one should be merged **AFTER** #102 is in.

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go