### PR TITLE
Make plot_cavity.py Python 3 compatible

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -75,5 +75,5 @@ doc/gfx/cloc_tools.py.in  licensefile=.githooks/LICENSE-Python
 src/make_cmake_files.py   licensefile=.githooks/LICENSE-Python
 tools/codata.py.in        licensefile=.githooks/LICENSE-Python
 tools/pcmsolver.py.in     licensefile=.githooks/LICENSE-Python
-tools/plot_cavity.py.in   licensefile=.githooks/LICENSE-Python
+tools/plot_cavity.py      licensefile=.githooks/LICENSE-Python
 tests/make_cmake_files.py licensefile=.githooks/LICENSE-Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,9 @@
 - Documentation building on ReadTheDocs is fully functional again, thanks @arnfinn :tada:
   The build had been failing for a while since docs were generated for all files, including
   documentation files from previous build. Besides, source code doxygen blocks were not
-  exctracted when inside namespaces.
+  extracted when inside namespaces.
 - Compiler warning in the `Sphere` class due to a redeclaration of `operator<<`.
+- The `plot_cavity.py` script is now Python 3 compatible.
 
 ### Removed
 

--- a/tools/plot_cavity.py
+++ b/tools/plot_cavity.py
@@ -1,6 +1,6 @@
 #
 #  PCMSolver, an API for the Polarizable Continuum Model
-#  Copyright (C) 2017 Roberto Di Remigio, Luca Frediani and collaborators.
+#  Copyright (C) 2018 Roberto Di Remigio, Luca Frediani and collaborators.
 #
 #  This file is part of PCMSolver.
 #
@@ -90,11 +90,9 @@ def shiftedColorMap(cmap, start=0, midpoint=0.5, stop=1.0, name='shiftedcmap'):
     reg_index = np.linspace(start, stop, 257)
 
     # shifted index to match the data
-    shift_index = np.hstack([
-        np.linspace(
-            0.0, midpoint, 128, endpoint=False), np.linspace(
-                midpoint, 1.0, 129, endpoint=True)
-    ])
+    shift_index = np.hstack(
+        [np.linspace(0.0, midpoint, 128, endpoint=False),
+         np.linspace(midpoint, 1.0, 129, endpoint=True)])
 
     for ri, si in zip(reg_index, shift_index):
         r, g, b, a = cmap(ri)
@@ -134,10 +132,9 @@ def plot(cavity_npz, surf_func_npy=None):
         colors = mappable.to_rgba(surf_func.flatten())
     # Generate list of vertices
     vertices = [
-        list(zip(cavity['vertices_' + str(i)][0, :],
-                 cavity['vertices_' + str(i)][1, :],
-                 cavity['vertices_' + str(i)][2, :]))
-        for i in range(nElements)
+        list(
+            zip(cavity['vertices_' + str(i)][0, :], cavity['vertices_' + str(i)][1, :], cavity['vertices_' + str(i)][
+                2, :])) for i in range(nElements)
     ]
     elements = Poly3DCollection(vertices, facecolors=colors)
     ax.add_collection3d(elements)

--- a/tools/plot_cavity.py
+++ b/tools/plot_cavity.py
@@ -116,7 +116,7 @@ def plot(cavity_npz, surf_func_npy=None):
 
     cavity = np.load(cavity_npz)
 
-    nElements = cavity['elements']
+    nElements = cavity['elements'][0]
     centroids = cavity['centers']
 
     # Plot collocation points
@@ -134,7 +134,9 @@ def plot(cavity_npz, surf_func_npy=None):
         colors = mappable.to_rgba(surf_func.flatten())
     # Generate list of vertices
     vertices = [
-        zip(cavity['vertices_' + str(i)][0, :], cavity['vertices_' + str(i)][1, :], cavity['vertices_' + str(i)][2, :])
+        list(zip(cavity['vertices_' + str(i)][0, :],
+                 cavity['vertices_' + str(i)][1, :],
+                 cavity['vertices_' + str(i)][2, :]))
         for i in range(nElements)
     ]
     elements = Poly3DCollection(vertices, facecolors=colors)


### PR DESCRIPTION
## Description
Turns out `plot_cavity.py` wouldn't run properly with Python 3. This PR fixes the problem.

## Todos
<!--- Notable points that this PR has either accomplished or will accomplish. -->
* **User-Facing for Release Notes**
  - [x] Fix Python 3 compatibility of `plot_cavity.py` script

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go