### PR TITLE
Fix MACOSX_RPATH

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ if(NOT STATIC_LIBRARY_ONLY)
     set_target_properties(pcm-shared PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR}
                                                 CXX_VISIBILITY_PRESET hidden
                                                 VISIBILITY_INLINES_HIDDEN 1
+                                                MACOSX_RPATH ON
                                                 OUTPUT_NAME "pcm"
                                                 EXPORT_NAME "pcm")
 


### PR DESCRIPTION
## Description
Fix `MACOSX_RPATH` CMake property for the shared `libpcm`. This completes #117 and closes #90 

## How Has This Been Tested?
Compiled on Mac, tests run and pass, checked with `otool` that everything points to the correct locations.

## Todos
<!--- Notable points that this PR has either accomplished or will accomplish. -->
* **Developer Interest**
<!--- Changes affecting developers -->
  - [x] Set `MACOSX_RPATH` CMake property to `ON`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go

Co-authored-by: Roberto Di Remigio <roberto.diremigio@gmail.com>