### PR TITLE
Install docopt with PCMSolver

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -32,10 +32,28 @@ file(
 install(
   FILES
     ${PROJECT_BINARY_DIR}/${PYMOD_INSTALL_FULLDIR}/__init__.py
-    ${PROJECT_BINARY_DIR}/${PYMOD_INSTALL_FULLDIR}/pcmdata.py
     ${PROJECT_BINARY_DIR}/${PYMOD_INSTALL_FULLDIR}/getkw.py
+    ${PROJECT_BINARY_DIR}/${PYMOD_INSTALL_FULLDIR}/pcmdata.py
     ${PROJECT_BINARY_DIR}/${PYMOD_INSTALL_FULLDIR}/pcmparser.py
     ${PROJECT_BINARY_DIR}/${PYMOD_INSTALL_FULLDIR}/pyparsing.py
   DESTINATION
     ${PYMOD_INSTALL_FULLDIR}
   )
+
+# Install docopt.py provided by Autocmake
+file(TO_NATIVE_PATH "${CMAKE_INSTALL_LIBDIR}/${PYMOD_INSTALL_LIBDIR}/docopt" PYMOD_INSTALL_EXTDIR)
+file(
+  COPY
+    ${PROJECT_SOURCE_DIR}/cmake/autocmake/external/__init__.py
+    ${PROJECT_SOURCE_DIR}/cmake/autocmake/external/docopt.py
+  DESTINATION
+  ${PROJECT_BINARY_DIR}/${PYMOD_INSTALL_FULLDIR}/external
+  )
+install(
+  FILES
+    ${PROJECT_BINARY_DIR}/${PYMOD_INSTALL_FULLDIR}/external/__init__.py
+    ${PROJECT_BINARY_DIR}/${PYMOD_INSTALL_FULLDIR}/external/docopt.py
+  DESTINATION
+    ${PYMOD_INSTALL_FULLDIR}/external
+  )
+

--- a/tools/go_pcm.py.in
+++ b/tools/go_pcm.py.in
@@ -29,7 +29,7 @@ Parses the PCMSolver input file and launches a standalone calculation with the
 run_pcm executable.
 """
 
-import docopt
+from pcmsolver.external import docopt
 import os
 import subprocess
 import sys

--- a/tools/plot_cavity.py
+++ b/tools/plot_cavity.py
@@ -120,8 +120,8 @@ def plot(cavity_npz, surf_func_npy=None):
     # Generate list of vertices
     vertices = [
         list(
-            zip(cavity['vertices_' + str(i)][0, :], cavity['vertices_' + str(i)][1, :], cavity['vertices_' + str(i)][
-                2, :])) for i in range(nElements)
+            zip(cavity['vertices_' + str(i)][0, :], cavity['vertices_' + str(i)][1, :],
+                cavity['vertices_' + str(i)][2, :])) for i in range(nElements)
     ]
     elements = Poly3DCollection(vertices, facecolors=colors)
     ax.add_collection3d(elements)


### PR DESCRIPTION
## Description
Installs `docopt` (provided with Autocmake) alongside the PCMSolver Python modules/scripts.

## Motivation and Context
Removes the necessity for downstream projects to satisfy the dependency on `docopt`.

## Todos
* **User-Facing for Release Notes**
  - [x] `docopt` is now installed alongside PCMSolver.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go

