### PR TITLE
[WIP] Use runtest to run the standalone tests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,14 +7,15 @@ name = "pypi"
 
 [packages]
 
+PyYAML = "*"
 Pygments = "*"
+Sphinx = "*"
 breathe = "*"
 docopt = "*"
 matplotlib = "*"
 pyparsing = "*"
-PyYAML = "*"
 recommonmark = "*"
-Sphinx = "*"
+runtest = "*"
 sphinx_rtd_theme = "*"
 sphinxcontrib-bibtex = "*"
 yapf = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "48084d78a10e199dcab5f5012d4458b6c47ab8054af862ed5a9a900f79406c0d"
+            "sha256": "eb9681ab5872423273fdec075e62fa06a16578cea5b98db13f00ce6699d5958a"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -182,10 +182,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:99276dc6e3a7851f32027a68f1095cd3f77c148091b092ea867a351811cfe388",
-                "sha256:5d50835fdf0a7edf0b55e311b7c887786504efea1177abd7e69329a8e5ea619e"
+                "sha256:e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0",
+                "sha256:f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b"
             ],
-            "version": "==16.8"
+            "version": "==17.1"
         },
         "pybtex": {
             "hashes": [
@@ -272,6 +272,12 @@
                 "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
             ],
             "version": "==2.18.4"
+        },
+        "runtest": {
+            "hashes": [
+                "sha256:008371d7ce6d103dbe63bf04ea166c36d69f46f6c2f1768b4d08b53f566bf8a9"
+            ],
+            "version": "==2.1.0"
         },
         "six": {
             "hashes": [

--- a/default.nix
+++ b/default.nix
@@ -51,5 +51,6 @@ in
     shellHook = ''
     export NINJA_STATUS="[Built edge %f of %t in %e sec]"
     SOURCE_DATE_EPOCH=$(date +%s)
+    source $(pipenv --venv)/bin/activate
     '';
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ matplotlib
 pyparsing
 pyyaml
 recommonmark
+runtest
 sphinx
 sphinx-rtd-theme
 sphinxcontrib-bibtex


### PR DESCRIPTION
The standalone tests in the `standalone` subdirectory are now run, but their results are not tested against a reference. This PR aims at hooking up with [`runtest`](http://runtest.readthedocs.io/en/latest/index.html)

## Motivation and Context
The standalone tests were created to test the interaction of the Python parsing script and the `run_pcm` standalone executable. However, if anything breaks somewhere else, it won't be caught anywhere.

## Todos
<!--- Notable points that this PR has either accomplished or will accomplish. -->
* **Developer Interest**
<!--- Changes affecting developers -->
  - [x] Install `runtest` in a virtual environment.
  - [ ] Hook up with `runtest`
  - [ ] Update developers documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Questions
Note that `runtest` will be a dependency for development. You will need to have it installed on your system or work in a virtual environment.

## Status
<!--- Check this box when ready to be merged -->
- [ ]  Ready to go


