### PR TITLE
Remove DTOR and operator<< from derived classes

### DIFF
--- a/src/bi_operators/Collocation.hpp
+++ b/src/bi_operators/Collocation.hpp
@@ -61,7 +61,6 @@ class Collocation __final : public IBoundaryIntegralOperator {
 public:
   Collocation();
   Collocation(double fac);
-  virtual ~Collocation() {}
 
 private:
   /*! Scaling factor for the diagonal elements of the matrix representation of

--- a/src/bi_operators/Purisima.hpp
+++ b/src/bi_operators/Purisima.hpp
@@ -58,7 +58,6 @@ class Purisima __final : public IBoundaryIntegralOperator {
 public:
   Purisima();
   Purisima(double fac);
-  virtual ~Purisima() {}
 
 private:
   /*! Scaling factor for the diagonal elements of the matrix representation of

--- a/src/cavity/GePolCavity.hpp
+++ b/src/cavity/GePolCavity.hpp
@@ -65,10 +65,6 @@ public:
               double pr,
               double minR,
               const std::string & suffix = "");
-  virtual ~GePolCavity() {}
-  friend std::ostream & operator<<(std::ostream & os, GePolCavity & cavity) {
-    return cavity.printCavity(os);
-  }
 
 private:
   double averageArea;

--- a/src/cavity/RestartCavity.hpp
+++ b/src/cavity/RestartCavity.hpp
@@ -46,11 +46,7 @@ namespace cavity {
 class RestartCavity __final : public ICavity {
 public:
   RestartCavity(const std::string & _fname) : file(_fname) { makeCavity(); }
-  virtual ~RestartCavity() {}
   virtual void makeCavity() __override { loadCavity(file); }
-  friend std::ostream & operator<<(std::ostream & os, RestartCavity & cavity) {
-    return cavity.printCavity(os);
-  }
 
 private:
   std::string file;

--- a/src/green/AnisotropicLiquid.hpp
+++ b/src/green/AnisotropicLiquid.hpp
@@ -59,14 +59,8 @@ public:
    */
   AnisotropicLiquid(const Eigen::Vector3d & eigen_eps,
                     const Eigen::Vector3d & euler_ang);
-  virtual ~AnisotropicLiquid() {}
-
   virtual double permittivity() const __override __final {
     PCMSOLVER_ERROR("permittivity() only implemented for uniform dielectrics");
-  }
-
-  friend std::ostream & operator<<(std::ostream & os, AnisotropicLiquid & gf) {
-    return gf.printObject(os);
   }
 
 private:

--- a/src/green/GreensFunction.hpp
+++ b/src/green/GreensFunction.hpp
@@ -50,7 +50,6 @@ template <typename DerivativeTraits, typename ProfilePolicy>
 class GreensFunction : public IGreensFunction {
 public:
   GreensFunction(const ProfilePolicy & p) : delta_(1.0e-04), profile_(p) {}
-  virtual ~GreensFunction() {}
   /*! @{ Methods to sample the Green's function directional derivatives */
   /*! Returns value of the directional derivative of the
    *  Greens's function for the pair of points p1, p2:
@@ -138,10 +137,6 @@ public:
     return pcm::is_same<ProfilePolicy, dielectric_profile::Uniform>::value;
   }
 
-  friend std::ostream & operator<<(std::ostream & os, GreensFunction & gf) {
-    return gf.printObject(os);
-  }
-
 protected:
   /*! Evaluates the Green's function given a pair of points
    *  \param[in] source the source point
@@ -185,7 +180,6 @@ template <typename ProfilePolicy>
 class GreensFunction<Stencil, ProfilePolicy> : public IGreensFunction {
 public:
   GreensFunction(const ProfilePolicy & p) : delta_(1.0e-04), profile_(p) {}
-  virtual ~GreensFunction() {}
   /*! @{ Methods to sample the Green's function directional derivatives */
   /*! Returns value of the directional derivative of the
    *  Greens's function for the pair of points p1, p2:
@@ -270,10 +264,6 @@ public:
    */
   virtual bool uniform() const __final __override {
     return pcm::is_same<ProfilePolicy, dielectric_profile::Uniform>::value;
-  }
-
-  friend std::ostream & operator<<(std::ostream & os, GreensFunction & gf) {
-    return gf.printObject(os);
   }
 
 protected:

--- a/src/green/IonicLiquid.hpp
+++ b/src/green/IonicLiquid.hpp
@@ -55,14 +55,9 @@ class IonicLiquid __final
     : public GreensFunction<DerivativeTraits, dielectric_profile::Yukawa> {
 public:
   IonicLiquid(double eps, double k);
-  virtual ~IonicLiquid() {}
 
   virtual double permittivity() const __override __final {
     PCMSOLVER_ERROR("permittivity() only implemented for uniform dielectrics");
-  }
-
-  friend std::ostream & operator<<(std::ostream & os, IonicLiquid & gf) {
-    return gf.printObject(os);
   }
 
 private:

--- a/src/green/SphericalDiffuse.hpp
+++ b/src/green/SphericalDiffuse.hpp
@@ -84,14 +84,8 @@ public:
     initSphericalDiffuse();
   }
 
-  virtual ~SphericalDiffuse() {}
-
   virtual double permittivity() const __override __final {
     PCMSOLVER_ERROR("permittivity() only implemented for uniform dielectrics");
-  }
-
-  friend std::ostream & operator<<(std::ostream & os, SphericalDiffuse & gf) {
-    return gf.printObject(os);
   }
 
   /*! \brief Returns Coulomb singularity separation coefficient

--- a/src/green/SphericalSharp.hpp
+++ b/src/green/SphericalSharp.hpp
@@ -67,7 +67,6 @@ public:
    * \param[in] l maximum value of angular momentum
    */
   SphericalSharp(double e, double esolv, double r, const Eigen::Vector3d & o, int l);
-  virtual ~SphericalSharp() {}
 
   virtual double permittivity() const __override __final {
     PCMSOLVER_ERROR("permittivity() only implemented for uniform dielectrics");
@@ -96,9 +95,6 @@ public:
                                   const Eigen::Vector3d & p1,
                                   const Eigen::Vector3d & p2) const;
 
-  friend std::ostream & operator<<(std::ostream & os, SphericalSharp & gf) {
-    return gf.printObject(os);
-  }
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 private:

--- a/src/green/UniformDielectric.hpp
+++ b/src/green/UniformDielectric.hpp
@@ -54,14 +54,9 @@ class UniformDielectric __final
     : public GreensFunction<DerivativeTraits, dielectric_profile::Uniform> {
 public:
   UniformDielectric(double eps);
-  virtual ~UniformDielectric() {}
 
   virtual double permittivity() const __override __final {
     return this->profile_.epsilon;
-  }
-
-  friend std::ostream & operator<<(std::ostream & os, UniformDielectric & gf) {
-    return gf.printObject(os);
   }
 
 private:

--- a/src/green/Vacuum.hpp
+++ b/src/green/Vacuum.hpp
@@ -58,14 +58,9 @@ class Vacuum __final
     : public GreensFunction<DerivativeTraits, dielectric_profile::Uniform> {
 public:
   Vacuum();
-  virtual ~Vacuum() {}
 
   virtual double permittivity() const __override __final {
     return this->profile_.epsilon;
-  }
-
-  friend std::ostream & operator<<(std::ostream & os, Vacuum & gf) {
-    return gf.printObject(os);
   }
 
 private:

--- a/src/solver/CPCMSolver.hpp
+++ b/src/solver/CPCMSolver.hpp
@@ -64,10 +64,6 @@ public:
    */
   CPCMSolver(bool symm, double corr)
       : ISolver(), hermitivitize_(symm), correction_(corr) {}
-  virtual ~CPCMSolver() {}
-  friend std::ostream & operator<<(std::ostream & os, CPCMSolver & solver) {
-    return solver.printSolver(os);
-  }
 
 private:
   /*! Whether the system matrix has to be symmetrized */

--- a/src/solver/IEFSolver.hpp
+++ b/src/solver/IEFSolver.hpp
@@ -77,7 +77,6 @@ public:
    *  \param[in] symm whether the system matrix has to be symmetrized
    */
   IEFSolver(bool symm) : ISolver(), hermitivitize_(symm) {}
-  virtual ~IEFSolver() {}
   /*! \brief Builds PCM matrix for an anisotropic environment
    *  \param[in] cavity the cavity to be used.
    *  \param[in] gf_i Green's function inside the cavity
@@ -98,9 +97,6 @@ public:
                             const IGreensFunction & gf_i,
                             const IGreensFunction & gf_o,
                             const IBoundaryIntegralOperator & op);
-  friend std::ostream & operator<<(std::ostream & os, IEFSolver & solver) {
-    return solver.printSolver(os);
-  }
 
 private:
   /*! Whether the system matrix has to be symmetrized */


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Clean up derived classes headers a bit by removing useless function declarations. These are not overridden and thus are just boilerplate cluttering the header files of the derived classes.

## Todos
* **Developer Interest**
  - [x] Clean up derived classes headers


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Status
- [x]  Ready to go