### PR TITLE
FIx handling of pcmsolver.f90 file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@
   This choice was made to simplify the set up of the ReadTheDocs and local
   documentation building procedures and to minimize the chances of breaking
   either.
+- The Fortran API bindings file `pcmsolver.f90` is now installed alongside the
+  `pcmsolver.h` header file. The users will have to compile it explicitly to
+  get the type checking from the API redeclaration in Fortran 90.
+  The file is always installed.
+- The `ENABLE_Fortran_API` configuration option has been renamed
+  `TEST_Fortran_API`, since it now only triggers compilation of the
+  `Fortran_host` test case.
 
 ## [Version 1.2.0-rc1] - 2018-03-02
 

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -1,12 +1,18 @@
-install(FILES ${PROJECT_SOURCE_DIR}/api/pcmsolver.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
-install(FILES ${PROJECT_SOURCE_DIR}/api/PCMInput.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
-
-if(ENABLE_Fortran_API)
-    add_library(fortran_bindings OBJECT ${PROJECT_SOURCE_DIR}/api/pcmsolver.f90)
-    set_target_properties(fortran_bindings
-      PROPERTIES
-        INCLUDE_DIRECTORIES ""
-        POSITION_INDEPENDENT_CODE 1
-      )
-    list(APPEND _objects $<TARGET_OBJECTS:fortran_bindings>)
-endif()
+install(
+  FILES
+    ${PROJECT_SOURCE_DIR}/api/pcmsolver.h
+  DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+  )
+install(
+  FILES
+    ${PROJECT_SOURCE_DIR}/api/PCMInput.h
+  DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+  )
+install(
+  FILES
+    ${PROJECT_SOURCE_DIR}/api/pcmsolver.f90
+  DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+  )

--- a/cmake/PCMSolverConfig.cmake.in
+++ b/cmake/PCMSolverConfig.cmake.in
@@ -8,7 +8,8 @@
 #
 #   PCMSolver_FOUND - true if PCMSolver and all required components found on the system
 #   PCMSolver_VERSION - PCMSolver version in format Major.Minor.Release
-#   PCMSolver_INCLUDE_DIRS - Directory where PCMSolver/pcmsolver.h header is located.
+#   PCMSolver_INCLUDE_DIRS - Directory where the PCMSolver/pcmsolver.h,
+#                            PCMSolver/PCMInput.h headers and PCMSolver/pcmsolver.f90 source file are located.
 #   PCMSolver_INCLUDE_DIR - same as DIRS
 #   PCMSolver_DEFINITIONS: Definitions necessary to use PCMSolver, namely USING_PCMSolver.
 #   PCMSolver_LIBRARIES - PCMSolver library to link against.

--- a/cmake/custom/api.cmake
+++ b/cmake/custom/api.cmake
@@ -5,14 +5,14 @@
 #
 # Variables defined::
 #
-#   ENABLE_Fortran_API
+#   TEST_Fortran_API
 #
 # autocmake.yml configuration::
 #
-#   docopt: "--fbindings=<ENABLE_Fortran_API> Enable compilation of Fortran 90 API bindings <ON/OFF> [default: ON]."
-#   define: "'-DENABLE_Fortran_API={0}'.format(arguments['--fbindings'])"
+#   docopt: "--fbindings=<TEST_Fortran_API> Enable compilation of Fortran 90 API bindings <ON/OFF> [default: ON]."
+#   define: "'-DTEST_Fortran_API={0}'.format(arguments['--fbindings'])"
 
-option(ENABLE_Fortran_API "Enable compilation of Fortran 90 API bindings" ON)
+option(TEST_Fortran_API "Enable compilation of Fortran 90 API bindings" ON)
 
 add_subdirectory(api)
 include_directories(${PROJECT_SOURCE_DIR}/api)

--- a/cmake/custom/api.cmake
+++ b/cmake/custom/api.cmake
@@ -1,7 +1,7 @@
 #.rst:
 #
 # Manage compilation of API.
-# Optionally, enable compilation of Fortran 90 API bindings.
+# Optionally, enable testing of Fortran 90 API bindings.
 #
 # Variables defined::
 #
@@ -9,10 +9,10 @@
 #
 # autocmake.yml configuration::
 #
-#   docopt: "--fbindings=<TEST_Fortran_API> Enable compilation of Fortran 90 API bindings <ON/OFF> [default: ON]."
+#   docopt: "--fbindings=<TEST_Fortran_API> Enable testing of Fortran 90 API bindings <ON/OFF> [default: ON]."
 #   define: "'-DTEST_Fortran_API={0}'.format(arguments['--fbindings'])"
 
-option(TEST_Fortran_API "Enable compilation of Fortran 90 API bindings" ON)
+option(TEST_Fortran_API "Enable testing of Fortran 90 API bindings" ON)
 
 add_subdirectory(api)
 include_directories(${PROJECT_SOURCE_DIR}/api)

--- a/cmake/downloaded/autocmake_omp.cmake
+++ b/cmake/downloaded/autocmake_omp.cmake
@@ -42,6 +42,7 @@ if(ENABLE_OPENMP)
         endif()
     endif()
 
+    # this is only needed for CMake below 3.5
     if(DEFINED CMAKE_Fortran_COMPILER_ID AND NOT DEFINED OpenMP_Fortran_FLAGS)
         # we do this in a pedestrian way because the Fortran support is relatively recent
         if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
@@ -50,8 +51,7 @@ if(ENABLE_OPENMP)
         if(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
             if(WIN32)
                 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Qopenmp")
-            elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel" AND
-                   "${CMAKE_Fortran_COMPILER_VERSION}" VERSION_LESS "15.0.0.20140528")
+            elseif("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_LESS "15.0.0.20140528")
                 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -openmp")
             else()
                 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qopenmp")

--- a/doc/users/building.rst
+++ b/doc/users/building.rst
@@ -49,7 +49,7 @@ Version 3.3.0 of Eigen libraries is shipped with the module and resides in the `
 Configuration
 -------------
 
-Configuration is managed through the front-end script ``setup`` residing in the
+Configuration is managed through the front-end script ``setup.py`` residing in the
 repository main directory. Issuing:
 
 .. code-block:: bash
@@ -151,7 +151,7 @@ Some options can only be tweaked `via` ``--cmake-options`` to the setup script:
 
 * ``ENABLE_TIMER`` Enable compilation of timer sources. Enabled by default.
 * ``BUILD_STANDALONE`` Enable compilation of standalone ``run_pcm`` executable. Enabled by default.
-* ``ENABLE_Fortran_API`` Enable compilation of the Fortran90 bindings for the API. Enabled by default.
+* ``TEST_Fortran_API`` Test the Fortran 90 bindings for the API. Enabled by default.
 * ``ENABLE_GENERIC`` Enable mostly static linking in shared library. Disabled by default.
 * ``ENABLE_TESTS`` Enable compilation of unit tests suite. Enabled by default.
 * ``SHARED_LIBRARY_ONLY`` Create only shared library. Opposite of ``--static``.

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ Options:
   --int64                                Enable 64bit integers [default: False].
   --omp                                  Enable OpenMP parallelization [default: False].
   --python=<PYTHON_INTERPRETER>          The Python interpreter (development version) to use. [default: ''].
-  --fbindings=<ENABLE_Fortran_API>       Enable compilation of Fortran 90 API bindings <ON/OFF> [default: ON].
+  --fbindings=<TEST_Fortran_API>         Enable compilation of Fortran 90 API bindings <ON/OFF> [default: ON].
   --boost-headers=<BOOST_INCLUDEDIR>     Include directories for Boost [default: ''].
   --boost-libraries=<BOOST_LIBRARYDIR>   Library directories for Boost [default: ''].
   --build-boost=<FORCE_CUSTOM_BOOST>     Deactivate Boost detection and build on-the-fly <ON/OFF> [default: OFF].
@@ -66,7 +66,7 @@ def gen_cmake_command(options, arguments):
     command.append('-DENABLE_64BIT_INTEGERS={0}'.format(arguments['--int64']))
     command.append('-DENABLE_OPENMP={0}'.format(arguments['--omp']))
     command.append('-DPYTHON_INTERPRETER="{0}"'.format(arguments['--python']))
-    command.append('-DENABLE_Fortran_API={0}'.format(arguments['--fbindings']))
+    command.append('-DTEST_Fortran_API={0}'.format(arguments['--fbindings']))
     command.append('-DBOOST_INCLUDEDIR="{0}"'.format(arguments['--boost-headers']))
     command.append('-DBOOST_LIBRARYDIR="{0}"'.format(arguments['--boost-libraries']))
     command.append('-DFORCE_CUSTOM_BOOST={0}'.format(arguments['--build-boost']))

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ Options:
   --int64                                Enable 64bit integers [default: False].
   --omp                                  Enable OpenMP parallelization [default: False].
   --python=<PYTHON_INTERPRETER>          The Python interpreter (development version) to use. [default: ''].
-  --fbindings=<TEST_Fortran_API>         Enable compilation of Fortran 90 API bindings <ON/OFF> [default: ON].
+  --fbindings=<TEST_Fortran_API>         Enable testing of Fortran 90 API bindings <ON/OFF> [default: ON].
   --boost-headers=<BOOST_INCLUDEDIR>     Include directories for Boost [default: ''].
   --boost-libraries=<BOOST_LIBRARYDIR>   Library directories for Boost [default: ''].
   --build-boost=<FORCE_CUSTOM_BOOST>     Deactivate Boost detection and build on-the-fly <ON/OFF> [default: OFF].

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,6 @@ add_subdirectory(utils)
 
 list(APPEND _objects
     $<TARGET_OBJECTS:cavity>
-    $<$<BOOL:${ENABLE_Fortran_API}>:$<TARGET_OBJECTS:fortran_bindings>>
     $<TARGET_OBJECTS:green>
     $<TARGET_OBJECTS:interface>
     $<TARGET_OBJECTS:metal>

--- a/src/pedra/pedra_cavity.F90
+++ b/src/pedra/pedra_cavity.F90
@@ -116,7 +116,7 @@
     natm   = mxcent
     numver = mxver
 
-    write(lvpri, '(a)') "Memory management through standard Fortran90 allocate/deallocate."
+    write(lvpri, '(a)') "Memory management through standard Fortran 90 allocate/deallocate."
 
     allocate(intsph(numts, 10))
     intsph = 0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,7 +46,7 @@ target_link_libraries(unit_tests
   )
 
 add_subdirectory(C_host)
-if(ENABLE_Fortran_API)
+if(TEST_Fortran_API)
   add_subdirectory(Fortran_host)
 endif()
 if(BUILD_STANDALONE)

--- a/tests/Fortran_host/CMakeLists.txt
+++ b/tests/Fortran_host/CMakeLists.txt
@@ -1,4 +1,8 @@
-add_executable(Fortran_host Fortran_host.f90 Fortran_host-modules.f90)
+add_executable(Fortran_host
+  Fortran_host.f90
+  Fortran_host-modules.f90
+  ${PROJECT_SOURCE_DIR}/api/pcmsolver.f90
+  )
 target_link_libraries(Fortran_host PCMSolver)
 set_target_properties(Fortran_host PROPERTIES LINKER_LANGUAGE Fortran)
 add_test(


### PR DESCRIPTION
## Description
This is  a fix spurred by writing the IJQC paper:
- [x] The Fortran 90 bindings file `pcmsolver.f90` is now installed alongside the headers. It is the responsibility of the host code to *optionally* compile it and link against PCMSolver.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Status
- [x]  Ready to go