### PR TITLE
Remove one library from link line of C_host

### DIFF
--- a/tests/C_host/CMakeLists.txt
+++ b/tests/C_host/CMakeLists.txt
@@ -5,7 +5,6 @@ target_include_directories(C_host
     ${PROJECT_SOURCE_DIR}/api
   )
 target_link_libraries(C_host PCMSolver)
-target_link_libraries(C_host m)
 set_target_properties(C_host
   PROPERTIES
     LINKER_LANGUAGE C
@@ -30,7 +29,6 @@ target_include_directories(fail-C_host
     ${PROJECT_SOURCE_DIR}/api
   )
 target_link_libraries(fail-C_host PCMSolver)
-target_link_libraries(fail-C_host m)
 set_target_properties(fail-C_host
   PROPERTIES
     LINKER_LANGUAGE C


### PR DESCRIPTION
## Description
Specifying `libm` in `target_link_libraries` is unnecessary when linking dynamically and it's put there automagically by CMake when linking statically.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go