### PR TITLE
Insert spaces after markup commands

### DIFF
--- a/doc/programmers/documentation.rst
+++ b/doc/programmers/documentation.rst
@@ -59,12 +59,14 @@ To have an offline version of the documentation just issue
 in the ``doc`` folder:
 
 .. code-block:: bash
+
    sphinx-build . _build
 
 The HTML will be stored in ``_build/``. Open the ``_build/index.html`` file with
 your browser to see and browse the documentation.
 
 .. warning::
+
    It is only possible to build documentation locally from within the ``doc``
    folder.
    This choice was made to simplify the set up of the ReadTheDocs and local


### PR DESCRIPTION
Fixes blanks after some rst markup commands that I, as usual, missed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go