### PR TITLE
Initialize raw pointer data members with nullptr

### DIFF
--- a/include/Citation.hpp
+++ b/include/Citation.hpp
@@ -36,7 +36,7 @@
 inline std::string citation_message() {
   // clang-format off
   const char * fmt =
-     "-----------------------------------------------------------------------\n"
+     "\n-----------------------------------------------------------------------\n"
      "   PCMSolver: An Open Source API for the Polarizable Continuum Model\n"
      "                   PCMSolver %s\n\n"
      "           Git: Branch {%s}, Revision {%s}\n\n"
@@ -45,7 +45,7 @@ inline std::string citation_message() {
      " Source repository: https://github.com/PCMSolver/pcmsolver\n"
      " Documentation: https://pcmsolver.readthedocs.io/\n"
      " PCMSolver initialized on: %s\n"
-     "-----------------------------------------------------------------------\n\n";
+     "-----------------------------------------------------------------------\n";
   // clang-format on
   // Get current time
   time_t rawtime;

--- a/src/interface/Meddle.cpp
+++ b/src/interface/Meddle.cpp
@@ -104,8 +104,7 @@ pcmsolver_context_t * pcmsolver_new_v1112(pcmsolver_reader_t input_reading,
 namespace pcm {
 void Meddle::CTORBody() {
   // Write PCMSolver output header
-  infoStream_ << std::endl;
-  infoStream_ << "~~~~~~~~~~ PCMSolver ~~~~~~~~~~" << std::endl;
+  infoStream_ << "~~~~~~~~~~ PCMSolver ~~~~~~~~~~\n";
   infoStream_ << "Using CODATA " << input_.CODATAyear() << " set of constants."
               << std::endl;
   infoStream_ << "Input parsing done " << input_.providedBy() << std::endl;
@@ -126,13 +125,23 @@ void Meddle::CTORBody() {
 }
 
 Meddle::Meddle(const Input & input, const HostWriter & write)
-    : hostWriter_(write), input_(input), hasDynamic_(false) {
+    : hostWriter_(write),
+      input_(input),
+      cavity_(__nullptr),
+      K_0_(__nullptr),
+      K_d_(__nullptr),
+      hasDynamic_(false) {
   input_.initMolecule();
   CTORBody();
 }
 
 Meddle::Meddle(const std::string & inputFileName, const HostWriter & write)
-    : hostWriter_(write), input_(Input(inputFileName)), hasDynamic_(false) {
+    : hostWriter_(write),
+      input_(Input(inputFileName)),
+      cavity_(__nullptr),
+      K_0_(__nullptr),
+      K_d_(__nullptr),
+      hasDynamic_(false) {
   input_.initMolecule();
   CTORBody();
 }
@@ -143,7 +152,12 @@ Meddle::Meddle(int nr_nuclei,
                int symmetry_info[],
                const HostWriter & write,
                const std::string & inputFileName)
-    : hostWriter_(write), input_(Input(inputFileName)), hasDynamic_(false) {
+    : hostWriter_(write),
+      input_(Input(inputFileName)),
+      cavity_(__nullptr),
+      K_0_(__nullptr),
+      K_d_(__nullptr),
+      hasDynamic_(false) {
   TIMER_ON("Meddle::initInput");
   initInput(nr_nuclei, charges, coordinates, symmetry_info);
   TIMER_OFF("Meddle::initInput");
@@ -157,7 +171,13 @@ Meddle::Meddle(int nr_nuclei,
                int symmetry_info[],
                const PCMInput & host_input,
                const HostWriter & write)
-    : hostWriter_(write), input_(Input(host_input)), hasDynamic_(false) {
+    : hostWriter_(write),
+      input_(Input(host_input)),
+      cavity_(__nullptr),
+      K_0_(__nullptr),
+      K_d_(__nullptr),
+      infoStream_("\n~~~~~~~~~~ PCMSolver ~~~~~~~~~~\n"),
+      hasDynamic_(false) {
   TIMER_ON("Meddle::initInput");
   initInput(nr_nuclei, charges, coordinates, symmetry_info);
   TIMER_OFF("Meddle::initInput");

--- a/src/interface/Meddle.hpp
+++ b/src/interface/Meddle.hpp
@@ -273,10 +273,10 @@ private:
   ISolver * K_0_;
   /*! Solver with dynamic permittivity */
   ISolver * K_d_;
-  /*! PCMSolver set up information */
-  mutable std::ostringstream infoStream_;
   /*! Whether K_d_ was initialized */
   bool hasDynamic_;
+  /*! PCMSolver set up information */
+  mutable std::ostringstream infoStream_;
   /*! SurfaceFunction map */
   mutable SurfaceFunctionMap functions_;
   /*! Common implemenation for the CTOR-s */


### PR DESCRIPTION
## Description
This uses the __nullptr preprocessor macro which resolves to the correct symbol based on the availability of C++11. The proposed change should make it harder to muck up with these pointers. (They should really become `std::unique_ptr`)

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go