### PR TITLE
Move import of local docopt in try block

### DIFF
--- a/tools/go_pcm.py.in
+++ b/tools/go_pcm.py.in
@@ -29,13 +29,13 @@ Parses the PCMSolver input file and launches a standalone calculation with the
 run_pcm executable.
 """
 
-from pcmsolver.external import docopt
 import os
 import subprocess
 import sys
 
 try:
     import pcmsolver as pcm
+    from pcmsolver.external import docopt
 except ImportError as ops:
     sys.stderr.write("{}\n\n".format(ops))
     sys.stderr.write("""You should update your PYTHONPATH to use go_pcm.py


### PR DESCRIPTION
## Description
This gives the more informative error message about `PYTHONPATH` upon import failure.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Status
- [x]  Ready to go


