### PR TITLE
Update citation.bib with Zenodo DOI

### DIFF
--- a/doc/snippets/citation.bib
+++ b/doc/snippets/citation.bib
@@ -1,5 +1,6 @@
 @misc{PCMSolver,
-  note = {\texttt{PCMSolver}, v1.2.0-rc1 an Application Programming Interface for the
-  Polarizable Continuum Model electrostatic problem, written by R.~Di~Remigio,
-  L.~Frediani and contributors (see http://pcmsolver.readthedocs.io/)"
+  note = "{\texttt{PCMSolver}, an open-source library for the polarizable continuum model
+  electrostatic problem, written by R.~Di~Remigio,
+  L.~Frediani and contributors (see http://pcmsolver.readthedocs.io/)}"
+  doi= "10.5281/zenodo.1156166"
 }


### PR DESCRIPTION
This uses the global DOI representing all versions of PCMSolver. It will correctly resolve to the latest version released, hence I've dropped the version number from the BibTeX entry.

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go