### PR TITLE
Fix calculation of S matrix inverse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@
   are handled in the API functions.
 - Properly enforce `const`-correctness of the `Meddle` object and of its usage
   in the context API.
+- [Cholesky decomposition](http://eigen.tuxfamily.org/dox/classEigen_1_1LLT.html) is used
+  in CPCMSolver to get the inverse of the S matrix. The robust Cholesky (LDLT)
+  previously used is broken with the latest version of the Intel compilers.
 
 ## [Version 1.2.0-rc1] - 2018-03-02
 

--- a/src/solver/CPCMSolver.cpp
+++ b/src/solver/CPCMSolver.cpp
@@ -76,7 +76,7 @@ Eigen::VectorXd CPCMSolver::computeCharge_impl(const Eigen::VectorXd & potential
   int nrBlocks = blockS_.size();
   int irrDim = fullDim / nrBlocks;
   charge.segment(irrep * irrDim, irrDim) =
-      -blockS_[irrep].ldlt().solve(potential.segment(irrep * irrDim, irrDim));
+      -blockS_[irrep].llt().solve(potential.segment(irrep * irrDim, irrDim));
 
   return charge;
 }


### PR DESCRIPTION
## Description
Robust Cholesky (LDLT) decomposition is broken with the latest Intel compilers. Using LLT fixes the problem.

## Todos
<!--- Notable points that this PR has either accomplished or will accomplish. -->
* **Developer Interest**
<!--- Changes affecting developers -->
  - [x] Use LLT instead of LDLT in `CPCMSolver`
* **User-Facing for Release Notes**
<!--- Changes affecting users -->
  - [ ] Feature2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go