### PR TITLE
Cherry picks from release/1.2

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,4 +11,4 @@
 - Ville Weijo (@vweijo)
 - Ward Poelmans (@wpoely86)
 
-This list was obtained 2018-03-02 by running `git shortlog -sn`
+This list was obtained 2018-04-27 by running `git shortlog -sn`

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,4 +11,4 @@
 - Ville Weijo (@vweijo)
 - Ward Poelmans (@wpoely86)
 
-This list was obtained 2018-05-01 by running `git shortlog -sn`
+This list was obtained 2018-05-02 by running `git shortlog -sn`

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,4 +11,4 @@
 - Ville Weijo (@vweijo)
 - Ward Poelmans (@wpoely86)
 
-This list was obtained 2018-04-27 by running `git shortlog -sn`
+This list was obtained 2018-05-01 by running `git shortlog -sn`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [Version 1.2.1] - 2018-05-01
+## [Version 1.2.1] - 2018-05-02
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [Version 1.2.1] - 2018-05-01
+
+### Fixed
+
+- Import of local copy of the `pyparsing` module in Getkw. Thanks @loriab for
+  the fix.
+- The `conf.py` documentation build script is restored to normal operation.
+
 ## [Version 1.2.0] - 2018-04-27
 
 ### Added
@@ -559,7 +567,8 @@
 
 ## v1.0.0 - 2014-09-30 [YANKED]
 
-[Unreleased]: https://github.com/PCMSolver/pcmsolver/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/PCMSolver/pcmsolver/compare/v1.2.1...HEAD
+[Version 1.2.0]: https://github.com/PCMSolver/pcmsolver/compare/v1.2.0...v1.2.1
 [Version 1.2.0]: https://github.com/PCMSolver/pcmsolver/compare/v1.2.0-rc1...v1.2.0
 [Version 1.2.0-rc1]: https://github.com/PCMSolver/pcmsolver/compare/v1.1.12...v1.2.0-rc1
 [Version 1.1.12]: https://github.com/PCMSolver/pcmsolver/compare/v1.1.11...v1.1.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [Version 1.2.0] - 2018-04-27
+
 ### Added
 
 - Green’s function for a spherical nanoparticle with **real** permittivity.
@@ -37,7 +39,7 @@
 - The `ENABLE_Fortran_API` configuration option has been renamed
   `TEST_Fortran_API`, since it now only triggers compilation of the
   `Fortran_host` test case.
-- **BREAKING CHANGE** The minimum required version of CMake is now 3.3 
+- **BREAKING CHANGE** The minimum required version of CMake is now 3.3
 
 ### Fixed
 
@@ -557,7 +559,8 @@
 
 ## v1.0.0 - 2014-09-30 [YANKED]
 
-[Unreleased]: https://github.com/PCMSolver/pcmsolver/compare/v1.2.0-rc1...HEAD
+[Unreleased]: https://github.com/PCMSolver/pcmsolver/compare/v1.2.0...HEAD
+[Version 1.2.0]: https://github.com/PCMSolver/pcmsolver/compare/v1.2.0-rc1...v1.2.0
 [Version 1.2.0-rc1]: https://github.com/PCMSolver/pcmsolver/compare/v1.1.12...v1.2.0-rc1
 [Version 1.1.12]: https://github.com/PCMSolver/pcmsolver/compare/v1.1.11...v1.1.12
 [Version 1.1.11]: https://github.com/PCMSolver/pcmsolver/compare/v1.1.10...v1.1.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -568,7 +568,7 @@
 ## v1.0.0 - 2014-09-30 [YANKED]
 
 [Unreleased]: https://github.com/PCMSolver/pcmsolver/compare/v1.2.1...HEAD
-[Version 1.2.0]: https://github.com/PCMSolver/pcmsolver/compare/v1.2.0...v1.2.1
+[Version 1.2.1]: https://github.com/PCMSolver/pcmsolver/compare/v1.2.0...v1.2.1
 [Version 1.2.0]: https://github.com/PCMSolver/pcmsolver/compare/v1.2.0-rc1...v1.2.0
 [Version 1.2.0-rc1]: https://github.com/PCMSolver/pcmsolver/compare/v1.1.12...v1.2.0-rc1
 [Version 1.1.12]: https://github.com/PCMSolver/pcmsolver/compare/v1.1.11...v1.1.12

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -78,9 +78,10 @@ mobj = sane_describe.match(pcmsolver_version)
 major = mobj.group('major')
 minor = mobj.group('minor')
 patch = mobj.group('patch')
-prere = mobj.group('prere')
-sha = mobj.group('sha')
-tweak = '+'.join([prere, sha])
+if mobj.group('prere'):
+    tweak = '+'.join([mobj.group('prere'), mobj.group('sha')])
+else:
+    tweak = sha = mobj.group('sha')
 language = 'en'
 exclude_patterns = ['_build']
 pygments_style = 'sphinx'

--- a/doc/programmers/versioning.rst
+++ b/doc/programmers/versioning.rst
@@ -286,7 +286,7 @@ tags as are created with the `GitHub interface
 * Delete tag::
 
     >>> git tag -d v1.1.12
-    >>> git push origin :refs/tags/v1.1a1
+    >>> git push origin :refs/tags/v1.1.12
 
 * Pull tags::
 

--- a/doc/programmers/versioning.rst
+++ b/doc/programmers/versioning.rst
@@ -71,6 +71,7 @@ This is the step-by-step guide to releasing a new version of PCMSolver:
        This list was obtained 2018-03-02 by running `git shortlog -sn`
 
 #. **CHECK** that the ``.mailmap`` file is up-to-date.
+#. **CHECK** that the documentation builds locally.
 #. **ACT** to check all the changed files in.
 #. **OBSERVE** current versioning state
 

--- a/doc/programmers/versioning.rst
+++ b/doc/programmers/versioning.rst
@@ -71,7 +71,6 @@ This is the step-by-step guide to releasing a new version of PCMSolver:
        This list was obtained 2018-03-02 by running `git shortlog -sn`
 
 #. **CHECK** that the ``.mailmap`` file is up-to-date.
-#. **UPDATE** the version number in the citation snippet in ``doc/snippets/citation.bib``.
 #. **ACT** to check all the changed files in.
 #. **OBSERVE** current versioning state
 
@@ -257,7 +256,7 @@ This is the step-by-step guide to releasing a new version of PCMSolver:
 
     ::
 
-      >>> git push origin release/1.2.Z
+      >>> git push origin release/1.2
 
       >>> git push origin v1.2.0
 

--- a/tools/metadata.py
+++ b/tools/metadata.py
@@ -1,7 +1,7 @@
-__version__ = '1.2.0'
-__version_long = '1.2.0+e1943b1'
-__version_upcoming_annotated_v_tag = '1.3.0'
-__version_most_recent_release = '1.2.0-rc1'
+__version__ = '1.2.1'
+__version_long = '1.2.1+zzzzzzz'
+__version_upcoming_annotated_v_tag = '1.2.2'
+__version_most_recent_release = '1.2.0'
 
 
 def version_formatter(dummy):

--- a/tools/metadata.py
+++ b/tools/metadata.py
@@ -1,7 +1,7 @@
-__version__ = '1.2.0-rc1'
-__version_long = '1.2.0-rc1+9a8c391'
-__version_upcoming_annotated_v_tag = '1.2.0'
-__version_most_recent_release = '1.1.12'
+__version__ = '1.2.0'
+__version_long = '1.2.0+zzzzzzz'
+__version_upcoming_annotated_v_tag = '1.3.0'
+__version_most_recent_release = '1.2.0'
 
 
 def version_formatter(dummy):

--- a/tools/metadata.py
+++ b/tools/metadata.py
@@ -1,5 +1,5 @@
 __version__ = '1.2.1'
-__version_long = '1.2.1+a7f13ef'
+__version_long = '1.2.1+zzzzzzz'
 __version_upcoming_annotated_v_tag = '1.2.2'
 __version_most_recent_release = '1.2.0'
 

--- a/tools/metadata.py
+++ b/tools/metadata.py
@@ -1,5 +1,5 @@
 __version__ = '1.2.1'
-__version_long = '1.2.1+zzzzzzz'
+__version_long = '1.2.1+a7f13ef'
 __version_upcoming_annotated_v_tag = '1.2.2'
 __version_most_recent_release = '1.2.0'
 

--- a/tools/metadata.py
+++ b/tools/metadata.py
@@ -1,7 +1,7 @@
 __version__ = '1.2.0'
-__version_long = '1.2.0+zzzzzzz'
+__version_long = '1.2.0+e1943b1'
 __version_upcoming_annotated_v_tag = '1.3.0'
-__version_most_recent_release = '1.2.0'
+__version_most_recent_release = '1.2.0-rc1'
 
 
 def version_formatter(dummy):

--- a/tools/metadata.py
+++ b/tools/metadata.py
@@ -1,5 +1,5 @@
 __version__ = '1.2.1'
-__version_long = '1.2.1+zzzzzzz'
+__version_long = '1.2.1+fa7c826'
 __version_upcoming_annotated_v_tag = '1.2.2'
 __version_most_recent_release = '1.2.0'
 

--- a/tools/versioner.py
+++ b/tools/versioner.py
@@ -131,7 +131,7 @@ def reconcile_and_compute_version_output(quiet=False):
         #   numerical comparisons such as M.m.p.t and thus can't handle
         #   prereleases and dev snapshots. We compute a Most Recent Ancestral
         #   Release tag (e.g., 1.0 or 1.12.1) for a backward release series.
-        backwardseries = mobj.group('forwardseries')
+        backwardseries = mobj.group('tag')
         if mobj.group('prere'):
             backwardseries = meta_most_recent_release
     else:

--- a/tools/versioner.py
+++ b/tools/versioner.py
@@ -14,11 +14,11 @@
 #
 from __future__ import print_function
 
+import argparse
 import os
 import re
-import sys
-import argparse
 import subprocess
+import sys
 
 
 def collect_version_input_from_fallback(meta_file='metadata.py'):
@@ -42,7 +42,7 @@ def is_git_repo(cwd='./', dot_git_qualifies=False, no_git_cmd_result=False):
     try:
         process = subprocess.Popen(
             command.split(), stderr=subprocess.PIPE, stdout=subprocess.PIPE, cwd=cwd, universal_newlines=True)
-    except EnvironmentError:
+    except EnvironmentError as e:
         # most likely, git command not available
         return no_git_cmd_result
 
@@ -88,7 +88,7 @@ def collect_version_input_from_git():
     if mobj.group('tag'):
         # We got a tag!
         # normal: 0.1-62-ga68d223
-        res['latest_annotated_v_tag'] = mobj.group('tag')  # drop the "v"; tag mismatch caught later
+        res['latest_annotated_v_tag'] = mobj.group('tag')[:-1]  # drop the "v"; tag mismatch caught later
         res['commits_since_tag'] = mobj.group('commits')
         res['seven_char_hash'] = mobj.group('gsha')[1:]  # drop the "g" git identifier
     else:


### PR DESCRIPTION
## Description

Cherry-picked all the commits that were on the `release/1.2` branch but not on the `master` branch. 

## Motivation and Context

Make sure `master` is up to date. `master` is now identical to `release/1.2`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Questions
- [ ]  I have cherry-picked **all** the commits, including "Bump version to..." and "Records tag for...". I am not sure the latter commits are necessary to cherry-pick, but this one made me unsure: 809e4a9a6013edb In this commit, `tools/versioner.py` was also changed, which I guess we want to include on `master`.
- [ ] Maybe *rebase* these commits into `master`?

## Status
<!--- Check this box when ready to be merged -->
- [x] Ready to go
- [ ] Cherry-pick to latest release branch
