### PR TITLE
v1211

### DIFF
--- a/src/cavity/ICavity.cpp
+++ b/src/cavity/ICavity.cpp
@@ -57,28 +57,30 @@ ICavity::ICavity(const Molecule & molec)
 }
 
 void ICavity::saveCavity(const std::string & fname) {
+  std::string ffname = std::tmpnam(nullptr);
+
   // Write everything in a single .npz binary file
   unsigned int dim = static_cast<unsigned int>(nElements_);
   // Write the number of elements, it will be used to check sanity of the save/load
   // operations.
   const unsigned int shape[] = {1};
-  cnpy::npz_save(fname, "elements", &dim, shape, 1, "w", false);
+  cnpy::npz_save(ffname, "elements", &dim, shape, 1, "w", false);
   // Write weights
-  cnpy::custom::npz_save(fname, "weights", elementArea_);
+  cnpy::custom::npz_save(ffname, "weights", elementArea_);
   // Write element sphere center
-  cnpy::custom::npz_save(fname, "elSphCenter", elementSphereCenter_);
+  cnpy::custom::npz_save(ffname, "elSphCenter", elementSphereCenter_);
   // Write element radius
-  cnpy::custom::npz_save(fname, "elRadius", elementRadius_);
+  cnpy::custom::npz_save(ffname, "elRadius", elementRadius_);
   // Write centers
-  cnpy::custom::npz_save(fname, "centers", elementCenter_);
+  cnpy::custom::npz_save(ffname, "centers", elementCenter_);
   // Write normals
-  cnpy::custom::npz_save(fname, "normals", elementNormal_);
+  cnpy::custom::npz_save(ffname, "normals", elementNormal_);
   for (PCMSolverIndex i = 0; i < nElements_; ++i) {
     // Write vertices
     cnpy::custom::npz_save(
-        fname, "vertices_" + pcm::to_string(i), elements_[i].vertices());
+        ffname, "vertices_" + pcm::to_string(i), elements_[i].vertices());
     // Write arcs
-    cnpy::custom::npz_save(fname, "arcs_" + pcm::to_string(i), elements_[i].arcs());
+    cnpy::custom::npz_save(ffname, "arcs_" + pcm::to_string(i), elements_[i].arcs());
   }
 }
 

--- a/tools/pcmparser.py
+++ b/tools/pcmparser.py
@@ -44,7 +44,6 @@ import os
 from copy import deepcopy
 import re
 
-from .getkw import Section, GetkwParser
 from .pcmdata import CODATAdict, allowedSolvents
 
 isAngstrom = False
@@ -80,6 +79,9 @@ def parse_pcm_input(inputFile, write_out=False):
 
     ...
     """
+    from importlib import reload
+    from . import getkw
+
     # Set up valid keywords.
     valid_keywords = setup_keywords()
 
@@ -88,7 +90,8 @@ def parse_pcm_input(inputFile, write_out=False):
 
     # Set up a GetKw object and let it parse our input:
     # here is where the magic happens.
-    inkw = GetkwParser().parseFile(uppercased)
+    getkw = reload(getkw)
+    inkw = getkw.GetkwParser().parseFile(uppercased)
     # Remove temporary file
     os.remove(uppercased)
     inkw.sanitize(valid_keywords)
@@ -153,6 +156,8 @@ def setup_keywords():
     """
     Sets up sections, keywords and respective callback functions.
     """
+    from .getkw import Section
+
     # Top-level section
     top = Section('toplevel', callback=verify_top)
     top.set_status(True)

--- a/tools/pyparsing.py
+++ b/tools/pyparsing.py
@@ -795,7 +795,7 @@ class ParseResults(object):
         return dir(super(ParseResults, self)) + list(self.keys())
 
 
-collections.MutableMapping.register(ParseResults)
+collections.abc.MutableMapping.register(ParseResults)
 
 
 def col(loc, strg):
@@ -2386,7 +2386,7 @@ class ParseExpression(ParserElement):
 
         if isinstance(exprs, basestring):
             self.exprs = [Literal(exprs)]
-        elif isinstance(exprs, collections.Sequence):
+        elif isinstance(exprs, collections.abc.Sequence):
             # if sequence of strings provided, wrap with Literal
             if all(isinstance(expr, basestring) for expr in exprs):
                 exprs = map(Literal, exprs)
@@ -3439,7 +3439,7 @@ def oneOf(strs, caseless=False, useRegex=True):
     symbols = []
     if isinstance(strs, basestring):
         symbols = strs.split()
-    elif isinstance(strs, collections.Sequence):
+    elif isinstance(strs, collections.abc.Sequence):
         symbols = list(strs[:])
     elif isinstance(strs, _generatorType):
         symbols = list(strs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Use labels to help the developers -->
<!--- Remove the unnecessary sections when filing -->

## Description
Don't actually merge this anywhere. It's just a record of stuff to make psi work.
- [x] the `getkw` bit allows sequential pcmsolver calcs w/o input keyword redefined error. already in #184
- [x] the `abc` squashes some warnings that imperil py39
- [x] the `tmpnam` is new and avoids intermittent errors running multiple pcm tests at the same time. this probably breaks the default of `loadCavity`, but that's not being used anyway :-) (at least in v1.2.1)

